### PR TITLE
Feature/issue 24 copy on esisting object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+### [1.2.1] TBD
+#### Added
+* Implemented new feature that allows the copy on an existing object instance (see: [Issue 24](https://github.com/HotelsDotCom/bull/issues/24))
 ### [1.2.0] 2019.02.25
 #### Added
 * Added possibility to skip the object validation (see: [Issue 31](https://github.com/HotelsDotCom/bull/issues/31))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-### [1.2.1] TBD
+### [1.2.1] 2019.03.05
 #### Added
 * Implemented new feature that allows the copy on an existing object instance (see: [Issue 24](https://github.com/HotelsDotCom/bull/issues/24))
 * Added profile: `fast` that skips the following plugin execution: `javadoc`, `checkstyle`, `pmd` and `jacoco`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ### [1.2.1] 2019.03.05
 #### Added
-* Implemented new feature that allows the copy on an existing object instance (see: [Issue 24](https://github.com/HotelsDotCom/bull/issues/24))
+* Implemented a new feature that allows the copy on an existing object instance (see: [Issue 24](https://github.com/HotelsDotCom/bull/issues/24))
 * Added profile: `fast` that skips the following plugin execution: `javadoc`, `checkstyle`, `pmd` and `jacoco`
 
 ### [1.2.0] 2019.02.25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ### [1.2.1] TBD
 #### Added
 * Implemented new feature that allows the copy on an existing object instance (see: [Issue 24](https://github.com/HotelsDotCom/bull/issues/24))
+* Added profile: `fast` that skips the following plugin execution: `javadoc`, `checkstyle`, `pmd` and `jacoco`
+
 ### [1.2.0] 2019.02.25
 #### Added
 * Added possibility to skip the object validation (see: [Issue 31](https://github.com/HotelsDotCom/bull/issues/31))

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@ Please describe the tests that you ran to verify your changes. Please also note 
 
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have commented on my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] Any dependent changes have been merged and published in downstream modules

--- a/README.md
+++ b/README.md
@@ -357,6 +357,25 @@ ToBean toBean = beanUtils.getTransformer()
                      .transform(fromBean, ToBean.class);
 ~~~
 
+### Copy on an existing instance:
+
+Given:
+
+~~~Java
+public class FromBean {                                     public class ToBean {                           
+   private final String name;                                  private String name;                   
+   private final FromSubBean nestedObject;                     private ToSubBean nestedObject;                    
+
+   // all args constructor                                     // constructor
+   // getters...                                               // getters and setters...
+}                                                           }
+~~~
+if you need to perform the copy on an already existing object, just do:
+~~~Java
+ToBean toBean = new ToBean();
+beanUtils.getTransformer().transform(fromBean, toBean);
+~~~
+
 More sample beans can be found in the test package: `com.hotels.beans.sample`
 
 ## Third party library comparison

--- a/config/checkstyle/suppression.xml
+++ b/config/checkstyle/suppression.xml
@@ -13,7 +13,7 @@
     <suppress checks="JavadocVariable" files="Filters.java"/>
 
     <!-- Checks for Braces into online instructions. -->
-    <suppress checks="NeedBraces" files=".*.java"/>
+    <suppress checks="VisibilityModifier" files=".*.java"/>
 
     <!-- Checks for class design  -->
     <suppress checks="DesignForExtension" files=".*[\\/]src[\\/](test|it)[\\/]|.*Test.java"/>

--- a/docs/site/markdown/transformer/samples.md
+++ b/docs/site/markdown/transformer/samples.md
@@ -301,4 +301,23 @@ ToBean toBean = beanUtils.getTransformer()
                      .transform(fromBean, ToBean.class);
 ~~~
 
+### Copy on an existing instance:
+
+Given:
+
+~~~Java
+public class FromBean {                                     public class ToBean {                           
+   private final String name;                                  private String name;                   
+   private final FromSubBean nestedObject;                     private ToSubBean nestedObject;                    
+
+   // all args constructor                                     // constructor
+   // getters...                                               // getters and setters...
+}                                                           }
+~~~
+if you need to perform the copy on an already existing object, just do:
+~~~Java
+ToBean toBean = new ToBean();
+beanUtils.getTransformer().transform(fromBean, toBean);
+~~~
+
 More sample beans can be found in the test package: `com.hotels.beans.sample`

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,8 @@
 				<checkstyle.check.skip>false</checkstyle.check.skip>
 				<checkstyle.includeTestSourceDirectory>true</checkstyle.includeTestSourceDirectory>
 				<jacoco.check.skip>false</jacoco.check.skip>
+				<pmd.check.skip>false</pmd.check.skip>
+				<javadoc.skip>false</javadoc.skip>
 			</properties>
 		</profile>
 		<profile>
@@ -148,6 +150,18 @@
 				<checkstyle.check.skip>true</checkstyle.check.skip>
 				<checkstyle.includeTestSourceDirectory>false</checkstyle.includeTestSourceDirectory>
 				<jacoco.check.skip>true</jacoco.check.skip>
+				<pmd.check.skip>true</pmd.check.skip>
+				<javadoc.skip>false</javadoc.skip>
+			</properties>
+		</profile>
+		<profile>
+			<id>fast</id>
+			<properties>
+				<checkstyle.check.skip>true</checkstyle.check.skip>
+				<checkstyle.includeTestSourceDirectory>false</checkstyle.includeTestSourceDirectory>
+				<jacoco.check.skip>true</jacoco.check.skip>
+				<pmd.check.skip>true</pmd.check.skip>
+				<javadoc.skip>true</javadoc.skip>
 			</properties>
 		</profile>
 		<!-- release profile -->
@@ -219,6 +233,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>${maven.javadoc.plugin.version}</version>
+				<configuration>
+					<skip>${javadoc.skip}</skip>
+				</configuration>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
@@ -361,6 +378,7 @@
 					<failOnViolation>false</failOnViolation>
 					<includeTests>false</includeTests>
 					<language>java</language>
+					<skip>${pmd.check.skip}</skip>
 				</configuration>
 				<executions>
 					<execution>

--- a/src/main/java/com/hotels/beans/populator/ArrayPopulator.java
+++ b/src/main/java/com/hotels/beans/populator/ArrayPopulator.java
@@ -21,7 +21,6 @@ import static java.util.Arrays.stream;
 import java.lang.reflect.Field;
 
 import com.hotels.beans.transformer.Transformer;
-import com.hotels.beans.utils.ClassUtils;
 
 /**
  * Populator for primitive types array.
@@ -41,7 +40,7 @@ class ArrayPopulator extends Populator<Object> implements ICollectionPopulator<O
      */
     @Override
     public Object getPopulatedObject(final Field field, final Object fieldValue) {
-        return getPopulatedObject(field.getType(), getReflectionUtils().getArrayType(field), fieldValue, null);
+        return getPopulatedObject(field.getType(), reflectionUtils.getArrayType(field), fieldValue, null);
     }
 
     /**
@@ -50,7 +49,6 @@ class ArrayPopulator extends Populator<Object> implements ICollectionPopulator<O
     @Override
     public Object getPopulatedObject(final Class<?> fieldType, final Class<?> genericFieldType, final Object fieldValue, final Class<?> nestedGenericClass) {
         final Object res;
-        final ClassUtils classUtils = getClassUtils();
         if (classUtils.isPrimitiveTypeArray(fieldValue) || classUtils.isPrimitiveOrSpecialType(genericFieldType)) {
             res = fieldValue;
         } else {

--- a/src/main/java/com/hotels/beans/populator/CollectionPopulator.java
+++ b/src/main/java/com/hotels/beans/populator/CollectionPopulator.java
@@ -46,8 +46,8 @@ class CollectionPopulator<K> extends Populator<Collection> implements ICollectio
      */
     @Override
     public Collection<K> getPopulatedObject(final Field field, final Collection fieldValue) {
-        final Class<?> genericClass = getReflectionUtils().getArgumentTypeClass(fieldValue, field.getDeclaringClass().getName(), field.getName(), true);
-        return getPopulatedObject(field.getType(), getReflectionUtils().getGenericFieldType(field), fieldValue, genericClass);
+        final Class<?> genericClass = reflectionUtils.getArgumentTypeClass(fieldValue, field.getDeclaringClass().getName(), field.getName(), true);
+        return getPopulatedObject(field.getType(), reflectionUtils.getGenericFieldType(field), fieldValue, genericClass);
     }
 
     /**
@@ -57,7 +57,7 @@ class CollectionPopulator<K> extends Populator<Collection> implements ICollectio
     @Override
     public Collection<K> getPopulatedObject(final Class<?> fieldType, final Class<?> genericFieldType, final Object fieldValue, final Class<?> nestedGenericClass) {
         final Collection res;
-        if (getClassUtils().isPrimitiveOrSpecialType(isNull(nestedGenericClass) ? genericFieldType : nestedGenericClass)) {
+        if (classUtils.isPrimitiveOrSpecialType(isNull(nestedGenericClass) ? genericFieldType : nestedGenericClass)) {
             res = (Collection) fieldValue;
         } else {
             Collector<Object, ?, ? extends Collection<Object>> collector = Set.class.isAssignableFrom(fieldType) ? toSet() : toList();

--- a/src/main/java/com/hotels/beans/populator/MapPopulator.java
+++ b/src/main/java/com/hotels/beans/populator/MapPopulator.java
@@ -44,7 +44,7 @@ class MapPopulator extends Populator<Map<?, ?>> {
      */
     @Override
     public Map<?, ?> getPopulatedObject(final Field field, final Map<?, ?> fieldValue) {
-        final MapType mapGenericType = getReflectionUtils().getMapGenericType(field.getGenericType(), field.getDeclaringClass().getName(), field.getName());
+        final MapType mapGenericType = reflectionUtils.getMapGenericType(field.getGenericType(), field.getDeclaringClass().getName(), field.getName());
         return getPopulatedObject(fieldValue, mapGenericType);
     }
 
@@ -57,8 +57,8 @@ class MapPopulator extends Populator<Map<?, ?>> {
     private Map<?, ?> getPopulatedObject(final Map<?, ?> fieldValue, final MapType mapType) {
         final MapElemType keyType = mapType.getKeyType();
         final MapElemType elemType = mapType.getElemType();
-        final boolean keyIsPrimitive = keyType.getClass().equals(ItemType.class) && getClassUtils().isPrimitiveOrSpecialType(((ItemType) keyType).getObjectClass());
-        final boolean elemIsPrimitive = elemType.getClass().equals(ItemType.class) && getClassUtils().isPrimitiveOrSpecialType(((ItemType) elemType).getObjectClass());
+        final boolean keyIsPrimitive = keyType.getClass().equals(ItemType.class) && classUtils.isPrimitiveOrSpecialType(((ItemType) keyType).getObjectClass());
+        final boolean elemIsPrimitive = elemType.getClass().equals(ItemType.class) && classUtils.isPrimitiveOrSpecialType(((ItemType) elemType).getObjectClass());
         Map<?, ?> populatedObject;
         if (keyIsPrimitive && elemIsPrimitive) {
             populatedObject = fieldValue;
@@ -84,7 +84,7 @@ class MapPopulator extends Populator<Map<?, ?>> {
     @SuppressWarnings("unchecked")
     private <T> T getElemValue(final MapElemType mapElemType, final boolean elemIsPrimitiveType, final T value) {
         final T elemValue;
-        if (elemIsPrimitiveType || getClassUtils().isPrimitiveOrSpecialType(value.getClass())) {
+        if (elemIsPrimitiveType || classUtils.isPrimitiveOrSpecialType(value.getClass())) {
             elemValue = value;
         } else {
             if (mapElemType.getClass().equals(ItemType.class)) {

--- a/src/main/java/com/hotels/beans/populator/Populator.java
+++ b/src/main/java/com/hotels/beans/populator/Populator.java
@@ -18,8 +18,6 @@ package com.hotels.beans.populator;
 
 import static com.hotels.beans.populator.PopulatorFactory.getPopulator;
 
-import static lombok.AccessLevel.NONE;
-
 import java.lang.reflect.Field;
 import java.util.Optional;
 
@@ -27,29 +25,25 @@ import com.hotels.beans.transformer.Transformer;
 import com.hotels.beans.utils.ClassUtils;
 import com.hotels.beans.utils.ReflectionUtils;
 
-import lombok.Getter;
-
 /**
  * Populator for collection or map objects.
  * @param <O> the type of the object to get populated.
  */
-@Getter
 public abstract class Populator<O> {
+    /**
+     * Reflection utils instance {@link ReflectionUtils}.
+     */
+    final ReflectionUtils reflectionUtils;
+
+    /**
+     * Class reflection utils instance {@link ClassUtils}.
+     */
+    final ClassUtils classUtils;
+
     /**
      * Transformer class instance {@link Transformer} containing the field mapping and transformation functions.
      */
-    @Getter(NONE)
     private final Transformer transformer;
-
-    /**
-     * Reflection utils class {@link ReflectionUtils}.
-     */
-    private final ReflectionUtils reflectionUtils;
-
-    /**
-     * Class reflection utils class {@link ClassUtils}.
-     */
-    private final ClassUtils classUtils;
 
     /**
      * Default constructor.

--- a/src/main/java/com/hotels/beans/transformer/AbstractTransformer.java
+++ b/src/main/java/com/hotels/beans/transformer/AbstractTransformer.java
@@ -179,4 +179,24 @@ abstract class AbstractTransformer implements Transformer {
      * @return a copy of the source object into the destination object
      */
     protected abstract <T, K> K transform(T sourceObj, Class<? extends K> targetClass, String breadcrumb);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final <T, K> void transform(final T sourceObj, final K targetObject) {
+        notNull(sourceObj, "The object to copy cannot be null!");
+        notNull(targetObject, "The destination object cannot be null!");
+        transform(sourceObj, targetObject, null);
+    }
+
+    /**
+     * Copies all properties from an object to a new one.
+     * @param sourceObj the source object
+     * @param targetObject the destination object
+     * @param breadcrumb the full path of the current field starting from his ancestor
+     * @param <T> the Source object type
+     * @param <K> the target object type
+     */
+    protected abstract <T, K> void transform(T sourceObj, K targetObject, String breadcrumb);
 }

--- a/src/main/java/com/hotels/beans/transformer/AbstractTransformer.java
+++ b/src/main/java/com/hotels/beans/transformer/AbstractTransformer.java
@@ -187,11 +187,6 @@ abstract class AbstractTransformer implements Transformer {
         transform(sourceObj, targetObject, null);
     }
 
-    @Override
-    public void resetFieldsTransformationSkip() {
-        settings.getFieldsToSkip().clear();
-    }
-
     /**
      * Copies all properties from an object to a new one.
      * @param sourceObj the source object

--- a/src/main/java/com/hotels/beans/transformer/AbstractTransformer.java
+++ b/src/main/java/com/hotels/beans/transformer/AbstractTransformer.java
@@ -29,38 +29,35 @@ import com.hotels.beans.utils.ClassUtils;
 import com.hotels.beans.utils.ReflectionUtils;
 import com.hotels.beans.utils.ValidationUtils;
 
-import lombok.Getter;
-
 /**
  * Utility methods for populating Mutable, Immutable and Hybrid JavaBeans properties via reflection.
  * Contains all method implementation that will be common to any {@link Transformer} implementation.
  */
-@Getter
 abstract class AbstractTransformer implements Transformer {
     /**
-     * Reflection utils class {@link ReflectionUtils}.
+     * Reflection utils instance {@link ReflectionUtils}.
      */
-    private final ReflectionUtils reflectionUtils;
+    final ReflectionUtils reflectionUtils;
 
     /**
-     * Class reflection utils class {@link ClassUtils}.
+     * Class uttils instance {@link ClassUtils}.
      */
-    private final ClassUtils classUtils;
+    final ClassUtils classUtils;
 
     /**
-     * Validation utils class {@link ValidationUtils}.
+     * Validation utils instance {@link ValidationUtils}.
      */
-    private final ValidationUtils validationUtils;
+    final ValidationUtils validationUtils;
 
     /**
-     * CacheManager class {@link CacheManager}.
+     * CacheManager instance {@link CacheManager}.
      */
-    private final CacheManager cacheManager;
+    final CacheManager cacheManager;
 
     /**
      * Contains both the field name mapping and the lambda function to be applied on fields.
      */
-    private final TransformerSettings transformerSettings;
+    final TransformerSettings settings;
 
     /**
      * Default constructor.
@@ -69,7 +66,7 @@ abstract class AbstractTransformer implements Transformer {
         this.reflectionUtils = new ReflectionUtils();
         this.classUtils = new ClassUtils();
         this.validationUtils = new ValidationUtils();
-        this.transformerSettings = new TransformerSettings();
+        this.settings = new TransformerSettings();
         this.cacheManager = CacheManagerFactory.getCacheManager("transformer");
     }
 
@@ -78,7 +75,7 @@ abstract class AbstractTransformer implements Transformer {
      */
     @Override
     public final Transformer withFieldMapping(final FieldMapping... fieldMapping) {
-        final Map<String, String> fieldsNameMapping = transformerSettings.getFieldsNameMapping();
+        final Map<String, String> fieldsNameMapping = settings.getFieldsNameMapping();
         for (FieldMapping mapping : fieldMapping) {
             fieldsNameMapping.put(mapping.getDestFieldName(), mapping.getSourceFieldName());
         }
@@ -91,7 +88,7 @@ abstract class AbstractTransformer implements Transformer {
     @Override
     public final void removeFieldMapping(final String destFieldName) {
         notNull(destFieldName, "The field name for which the mapping has to be removed cannot be null!");
-        transformerSettings.getFieldsNameMapping().remove(destFieldName);
+        settings.getFieldsNameMapping().remove(destFieldName);
     }
 
     /**
@@ -99,7 +96,7 @@ abstract class AbstractTransformer implements Transformer {
      */
     @Override
     public final void resetFieldsMapping() {
-        transformerSettings.getFieldsNameMapping().clear();
+        settings.getFieldsNameMapping().clear();
     }
 
     /**
@@ -108,7 +105,7 @@ abstract class AbstractTransformer implements Transformer {
     @Override
     @SuppressWarnings("unchecked")
     public final Transformer withFieldTransformer(final FieldTransformer... fieldTransformer) {
-        Map<String, Function<Object, Object>> fieldsTransformers = transformerSettings.getFieldsTransformers();
+        Map<String, Function<Object, Object>> fieldsTransformers = settings.getFieldsTransformers();
         for (FieldTransformer transformer : fieldTransformer) {
             fieldsTransformers.put(transformer.getDestFieldName(), transformer.getTransformerFunction());
         }
@@ -121,7 +118,7 @@ abstract class AbstractTransformer implements Transformer {
     @Override
     public final void removeFieldTransformer(final String destFieldName) {
         notNull(destFieldName, "The field name for which the transformer function has to be removed cannot be null!");
-        transformerSettings.getFieldsTransformers().remove(destFieldName);
+        settings.getFieldsTransformers().remove(destFieldName);
     }
 
     /**
@@ -129,7 +126,7 @@ abstract class AbstractTransformer implements Transformer {
      */
     @Override
     public final void resetFieldsTransformer() {
-        transformerSettings.getFieldsTransformers().clear();
+        settings.getFieldsTransformers().clear();
     }
 
     /**
@@ -137,7 +134,7 @@ abstract class AbstractTransformer implements Transformer {
      */
     @Override
     public final Transformer setDefaultValueForMissingField(final boolean useDefaultValue) {
-        transformerSettings.setSetDefaultValue(useDefaultValue);
+        settings.setSetDefaultValue(useDefaultValue);
         return this;
     }
 
@@ -146,7 +143,7 @@ abstract class AbstractTransformer implements Transformer {
      */
     @Override
     public final Transformer setFlatFieldNameTransformation(final boolean useFlatTransformation) {
-        transformerSettings.setFlatFieldNameTransformation(useFlatTransformation);
+        settings.setFlatFieldNameTransformation(useFlatTransformation);
         return this;
     }
 
@@ -155,7 +152,7 @@ abstract class AbstractTransformer implements Transformer {
      */
     @Override
     public Transformer setValidationDisabled(final boolean validationDisabled) {
-        transformerSettings.setValidationDisabled(validationDisabled);
+        settings.setValidationDisabled(validationDisabled);
         return this;
     }
 

--- a/src/main/java/com/hotels/beans/transformer/AbstractTransformer.java
+++ b/src/main/java/com/hotels/beans/transformer/AbstractTransformer.java
@@ -187,6 +187,11 @@ abstract class AbstractTransformer implements Transformer {
         transform(sourceObj, targetObject, null);
     }
 
+    @Override
+    public void resetFieldsTransformationSkip() {
+        settings.getFieldsToSkip().clear();
+    }
+
     /**
      * Copies all properties from an object to a new one.
      * @param sourceObj the source object

--- a/src/main/java/com/hotels/beans/transformer/Transformer.java
+++ b/src/main/java/com/hotels/beans/transformer/Transformer.java
@@ -36,6 +36,16 @@ public interface Transformer {
     <T, K> K transform(T sourceObj, Class<? extends K> targetClass);
 
     /**
+     * Copies all properties from an object to a new one.
+     * @param sourceObj the source object
+     * @param targetObject the destination object
+     * @param <T> the Source object type
+     * @param <K> the target object type
+     * @throws IllegalArgumentException if any parameter is invalid
+     */
+    <T, K> void transform(T sourceObj, K targetObject);
+
+    /**
      * Initializes the mapping between fields in the source object and the destination one.
      * @param fieldMapping the field mapping
      * @return the {@link Transformer} instance

--- a/src/main/java/com/hotels/beans/transformer/Transformer.java
+++ b/src/main/java/com/hotels/beans/transformer/Transformer.java
@@ -105,9 +105,4 @@ public interface Transformer {
      * @return the {@link Transformer} instance
      */
     Transformer setValidationDisabled(boolean validationDisabled);
-
-    /**
-     * Removes all the configured fields to skip.
-     */
-    void resetFieldsTransformationSkip();
 }

--- a/src/main/java/com/hotels/beans/transformer/Transformer.java
+++ b/src/main/java/com/hotels/beans/transformer/Transformer.java
@@ -105,4 +105,9 @@ public interface Transformer {
      * @return the {@link Transformer} instance
      */
     Transformer setValidationDisabled(boolean validationDisabled);
+
+    /**
+     * Removes all the configured fields to skip.
+     */
+    void resetFieldsTransformationSkip();
 }

--- a/src/main/java/com/hotels/beans/transformer/TransformerImpl.java
+++ b/src/main/java/com/hotels/beans/transformer/TransformerImpl.java
@@ -247,7 +247,7 @@ public class TransformerImpl extends AbstractTransformer {
      */
     private <T, K> void injectAllFields(final T sourceObj, final K targetObject, final String breadcrumb) {
         final Class<?> targetObjectClass = targetObject.getClass();
-        getClassUtils().getFields(targetObjectClass, true)
+        getClassUtils().getDeclaredFields(targetObjectClass, true)
                 //.parallelStream()
                 .forEach(field -> getReflectionUtils().setFieldValue(targetObject, field, getFieldValue(sourceObj, targetObjectClass, field, breadcrumb)));
     }

--- a/src/main/java/com/hotels/beans/transformer/TransformerImpl.java
+++ b/src/main/java/com/hotels/beans/transformer/TransformerImpl.java
@@ -54,7 +54,7 @@ public class TransformerImpl extends AbstractTransformer {
     @Override
     protected final <T, K> K transform(final T sourceObj, final Class<? extends K> targetClass, final String breadcrumb) {
         final K k;
-        final ClassType classType = getClassUtils().getClassType(targetClass);
+        final ClassType classType = classUtils.getClassType(targetClass);
         if (classType.is(MUTABLE)) {
             try {
                 k = targetClass.getDeclaredConstructor().newInstance();
@@ -65,13 +65,13 @@ public class TransformerImpl extends AbstractTransformer {
                 throw new InvalidBeanException(e.getMessage(), e);
             }
         } else {
-            k = injectValues(sourceObj, targetClass, getClassUtils().getAllArgsConstructor(targetClass), breadcrumb);
+            k = injectValues(sourceObj, targetClass, classUtils.getAllArgsConstructor(targetClass), breadcrumb);
             if (classType.is(MIXED)) {
                 injectNotFinalFields(sourceObj, k, breadcrumb);
             }
         }
-        if (!getTransformerSettings().isValidationDisabled()) {
-            getValidationUtils().validate(k);
+        if (!settings.isValidationDisabled()) {
+            validationUtils.validate(k);
         }
         return k;
     }
@@ -82,8 +82,8 @@ public class TransformerImpl extends AbstractTransformer {
     @Override
     protected final <T, K> void transform(final T sourceObj, final K targetObject, final String breadcrumb) {
         injectAllFields(sourceObj, targetObject, breadcrumb);
-        if (!getTransformerSettings().isValidationDisabled()) {
-            getValidationUtils().validate(targetObject);
+        if (!settings.isValidationDisabled()) {
+            validationUtils.validate(targetObject);
         }
     }
 
@@ -138,10 +138,10 @@ public class TransformerImpl extends AbstractTransformer {
      */
     private <K> boolean canBeInjectedByConstructorParams(final Constructor constructor, final Class<K> targetClass) {
         final String cacheKey = "CanBeInjectedByConstructorParams-" + constructor.getDeclaringClass().getCanonicalName();
-        return ofNullable(getCacheManager().getFromCache(cacheKey, Boolean.class)).orElseGet(() -> {
-            final boolean res = getClassUtils().getPrivateFinalFields(targetClass).size() == constructor.getParameterCount()
-                    && (getClassUtils().areParameterNamesAvailable(constructor) || getClassUtils().allParameterAnnotatedWith(constructor, ConstructorArg.class));
-            getCacheManager().cacheObject(cacheKey, res);
+        return ofNullable(cacheManager.getFromCache(cacheKey, Boolean.class)).orElseGet(() -> {
+            final boolean res = classUtils.getPrivateFinalFields(targetClass).size() == constructor.getParameterCount()
+                    && (classUtils.areParameterNamesAvailable(constructor) || classUtils.allParameterAnnotatedWith(constructor, ConstructorArg.class));
+            cacheManager.cacheObject(cacheKey, res);
             return res;
         });
     }
@@ -159,19 +159,19 @@ public class TransformerImpl extends AbstractTransformer {
      * @throws InvalidBeanException {@link InvalidBeanException} if there is an error while retrieving the constructor args parameter
      */
     private <T, K> Object[] getConstructorArgsValues(final T sourceObj, final Class<K> targetClass, final Constructor constructor, final String breadcrumb) {
-        final Parameter[] constructorParameters = getClassUtils().getConstructorParameters(constructor);
+        final Parameter[] constructorParameters = classUtils.getConstructorParameters(constructor);
         final Object[] constructorArgsValues = new Object[constructorParameters.length];
         range(0, constructorParameters.length)
                 //.parallel()
                 .forEach(i -> {
                     String destFieldName = getDestFieldName(constructorParameters[i], targetClass.getCanonicalName());
                     if (isNull(destFieldName)) {
-                        constructorArgsValues[i] =  getClassUtils().getDefaultTypeValue(constructorParameters[i].getType());
+                        constructorArgsValues[i] =  classUtils.getDefaultTypeValue(constructorParameters[i].getType());
                     } else {
                         String sourceFieldName = getSourceFieldName(destFieldName);
                         constructorArgsValues[i] =
-                                ofNullable(getFieldValue(sourceObj, sourceFieldName, targetClass, getClassUtils().getDeclaredField(targetClass, destFieldName), breadcrumb))
-                                .orElse(getClassUtils().getDefaultTypeValue(constructorParameters[i].getType()));
+                                ofNullable(getFieldValue(sourceObj, sourceFieldName, targetClass, classUtils.getDeclaredField(targetClass, destFieldName), breadcrumb))
+                                .orElse(classUtils.getDefaultTypeValue(constructorParameters[i].getType()));
                     }
                 });
         return constructorArgsValues;
@@ -192,7 +192,7 @@ public class TransformerImpl extends AbstractTransformer {
      * @return the source field name.
      */
     private String getSourceFieldName(final String fieldName) {
-        return ofNullable(getTransformerSettings().getFieldsNameMapping().get(fieldName)).orElse(fieldName);
+        return ofNullable(settings.getFieldsNameMapping().get(fieldName)).orElse(fieldName);
     }
 
     /**
@@ -203,17 +203,17 @@ public class TransformerImpl extends AbstractTransformer {
      */
     private String getDestFieldName(final Parameter constructorParameter, final String declaringClassName) {
         String cacheKey = "DestFieldName-" + declaringClassName + "-" + constructorParameter.getName();
-        return ofNullable(getCacheManager().getFromCache(cacheKey, String.class))
+        return ofNullable(cacheManager.getFromCache(cacheKey, String.class))
                 .orElseGet(() -> {
                     String destFieldName;
                     if (constructorParameter.isNamePresent()) {
                         destFieldName = constructorParameter.getName();
                     } else {
-                        destFieldName = ofNullable(getReflectionUtils().getParameterAnnotation(constructorParameter, ConstructorArg.class, declaringClassName))
+                        destFieldName = ofNullable(reflectionUtils.getParameterAnnotation(constructorParameter, ConstructorArg.class, declaringClassName))
                                 .map(ConstructorArg::value)
                                 .orElse(null);
                     }
-                    getCacheManager().cacheObject(cacheKey, destFieldName);
+                    cacheManager.cacheObject(cacheKey, destFieldName);
                     return destFieldName;
                 });
     }
@@ -230,7 +230,7 @@ public class TransformerImpl extends AbstractTransformer {
      * @throws InvalidBeanException {@link InvalidBeanException} if an error occurs while retrieving the value
      */
     private <T, K> Object[] getConstructorValuesFromFields(final T sourceObj, final Class<K> targetClass, final String breadcrumb) {
-        final List<Field> declaredFields = getClassUtils().getDeclaredFields(targetClass, true);
+        final List<Field> declaredFields = classUtils.getDeclaredFields(targetClass, true);
         return declaredFields.stream()
                 .map(field -> getFieldValue(sourceObj, targetClass, field, breadcrumb))
                 .toArray(Object[]::new);
@@ -247,9 +247,9 @@ public class TransformerImpl extends AbstractTransformer {
      */
     private <T, K> void injectAllFields(final T sourceObj, final K targetObject, final String breadcrumb) {
         final Class<?> targetObjectClass = targetObject.getClass();
-        getClassUtils().getDeclaredFields(targetObjectClass, true)
+        classUtils.getDeclaredFields(targetObjectClass, true)
                 //.parallelStream()
-                .forEach(field -> getReflectionUtils().setFieldValue(targetObject, field, getFieldValue(sourceObj, targetObjectClass, field, breadcrumb)));
+                .forEach(field -> reflectionUtils.setFieldValue(targetObject, field, getFieldValue(sourceObj, targetObjectClass, field, breadcrumb)));
     }
 
     /**
@@ -263,9 +263,9 @@ public class TransformerImpl extends AbstractTransformer {
      */
     private <T, K> void injectNotFinalFields(final T sourceObj, final K targetObject, final String breadcrumb) {
         final Class<?> targetObjectClass = targetObject.getClass();
-        getClassUtils().getNotFinalFields(targetObjectClass, true)
+        classUtils.getNotFinalFields(targetObjectClass, true)
                 //.parallelStream()
-                .forEach(field -> getReflectionUtils().setFieldValue(targetObject, field, getFieldValue(sourceObj, targetObjectClass, field, breadcrumb)));
+                .forEach(field -> reflectionUtils.setFieldValue(targetObject, field, getFieldValue(sourceObj, targetObjectClass, field, breadcrumb)));
     }
 
     /**
@@ -298,13 +298,13 @@ public class TransformerImpl extends AbstractTransformer {
      */
     private <T, K> Object getFieldValue(final T sourceObj, final String sourceFieldName, final Class<K> targetClass, final Field field, final String breadcrumb) {
         String fieldBreadcrumb = evalBreadcrumb(field.getName(), breadcrumb);
-        boolean primitiveType = getClassUtils().isPrimitiveType(field.getType());
-        boolean isFieldTransformerDefined = getTransformerSettings().getFieldsTransformers().containsKey(field.getName());
+        boolean primitiveType = classUtils.isPrimitiveType(field.getType());
+        boolean isFieldTransformerDefined = settings.getFieldsTransformers().containsKey(field.getName());
         Object fieldValue = getSourceFieldValue(sourceObj, sourceFieldName, field, isFieldTransformerDefined);
         if (nonNull(fieldValue)) {
             // is not a primitive type or an optional && there are no transformer function
             // defined it recursively evaluate the value
-            boolean notPrimitiveAndNotSpecialType = !primitiveType && !getClassUtils().isSpecialType(field.getType());
+            boolean notPrimitiveAndNotSpecialType = !primitiveType && !classUtils.isSpecialType(field.getType());
             if ((notPrimitiveAndNotSpecialType || Optional.class.isAssignableFrom(fieldValue.getClass()))
                     && !isFieldTransformerDefined) {
                 fieldValue = getFieldValue(targetClass, field, fieldValue, fieldBreadcrumb);
@@ -337,9 +337,9 @@ public class TransformerImpl extends AbstractTransformer {
     private <T> Object getSourceFieldValue(final T sourceObj, final String sourceFieldName, final Field field, final boolean isFieldTransformerDefined) {
         Object fieldValue = null;
         try {
-            fieldValue = getReflectionUtils().getFieldValue(sourceObj, sourceFieldName, field.getType());
+            fieldValue = reflectionUtils.getFieldValue(sourceObj, sourceFieldName, field.getType());
         } catch (MissingFieldException e) {
-            if (!isFieldTransformerDefined && !getTransformerSettings().isSetDefaultValue()) {
+            if (!isFieldTransformerDefined && !settings.isSetDefaultValue()) {
                 throw e;
             }
         } catch (Exception e) {
@@ -358,8 +358,8 @@ public class TransformerImpl extends AbstractTransformer {
      * @return the transformed field.
      */
     private Object getTransformedField(final Field field, final String breadcrumb, final Object fieldValue) {
-        String fieldName = getTransformerSettings().isFlatFieldNameTransformation() ? field.getName() : breadcrumb;
-        return ofNullable(getTransformerSettings().getFieldsTransformers().get(fieldName))
+        String fieldName = settings.isFlatFieldNameTransformation() ? field.getName() : breadcrumb;
+        return ofNullable(settings.getFieldsTransformers().get(fieldName))
                 .map(fieldTransformer -> fieldTransformer.apply(fieldValue))
                 .orElse(fieldValue);
     }

--- a/src/main/java/com/hotels/beans/transformer/TransformerSettings.java
+++ b/src/main/java/com/hotels/beans/transformer/TransformerSettings.java
@@ -48,6 +48,11 @@ final class TransformerSettings {
     private final Map<String, Function<Object, Object>> fieldsTransformers = new ConcurrentHashMap<>();
 
     /**
+     * Contains the list of fields that don't need to be transformed.
+     */
+    private final Map<String, String> fieldsToSkip = new ConcurrentHashMap<>();
+
+    /**
      * It allows to configure the transformer in order to set a default value in case some field is missing in the source object.
      * If set to true the default value is set, if false if it raises a: {@link com.hotels.beans.error.MissingFieldException} in case of missing fields.
      */

--- a/src/main/java/com/hotels/beans/transformer/TransformerSettings.java
+++ b/src/main/java/com/hotels/beans/transformer/TransformerSettings.java
@@ -48,11 +48,6 @@ final class TransformerSettings {
     private final Map<String, Function<Object, Object>> fieldsTransformers = new ConcurrentHashMap<>();
 
     /**
-     * Contains the list of fields that don't need to be transformed.
-     */
-    private final Map<String, String> fieldsToSkip = new ConcurrentHashMap<>();
-
-    /**
      * It allows to configure the transformer in order to set a default value in case some field is missing in the source object.
      * If set to true the default value is set, if false if it raises a: {@link com.hotels.beans.error.MissingFieldException} in case of missing fields.
      */

--- a/src/main/java/com/hotels/beans/utils/ClassUtils.java
+++ b/src/main/java/com/hotels/beans/utils/ClassUtils.java
@@ -70,7 +70,7 @@ public final class ClassUtils {
     private static final String CLAZZ_CANNOT_BE_NULL = "clazz cannot be null!";
 
     /**
-     * Reflection utils class {@link ReflectionUtils}.
+     * Reflection utils instance {@link ReflectionUtils}.
      */
     private final ReflectionUtils reflectionUtils;
 

--- a/src/main/java/com/hotels/beans/utils/ClassUtils.java
+++ b/src/main/java/com/hotels/beans/utils/ClassUtils.java
@@ -651,6 +651,22 @@ public final class ClassUtils {
     }
 
     /**
+     * Returns all class fields.
+     * @param clazz the class containing fields.
+     * @param skipStatic if true the static fields are skipped.
+     * @return a list containing all the not final fields.
+     */
+    @SuppressWarnings("unchecked")
+    public List<Field> getFields(final Class<?> clazz, final Boolean skipStatic) {
+        final String cacheKey = "ClassFields-" + clazz.getCanonicalName() + "-" + skipStatic;
+        return ofNullable(cacheManager.getFromCache(cacheKey, List.class)).orElseGet(() -> {
+            List<Field> notFinalFields = new ArrayList<>(getDeclaredFields(clazz, skipStatic));
+            cacheManager.cacheObject(cacheKey, notFinalFields);
+            return notFinalFields;
+        });
+    }
+
+    /**
      * Returns all the not final fields.
      * @param clazz the class containing fields.
      * @param skipStatic if true the static fields are skipped.

--- a/src/main/java/com/hotels/beans/utils/ClassUtils.java
+++ b/src/main/java/com/hotels/beans/utils/ClassUtils.java
@@ -651,22 +651,6 @@ public final class ClassUtils {
     }
 
     /**
-     * Returns all class fields.
-     * @param clazz the class containing fields.
-     * @param skipStatic if true the static fields are skipped.
-     * @return a list containing all the not final fields.
-     */
-    @SuppressWarnings("unchecked")
-    public List<Field> getFields(final Class<?> clazz, final Boolean skipStatic) {
-        final String cacheKey = "ClassFields-" + clazz.getCanonicalName() + "-" + skipStatic;
-        return ofNullable(cacheManager.getFromCache(cacheKey, List.class)).orElseGet(() -> {
-            List<Field> notFinalFields = new ArrayList<>(getDeclaredFields(clazz, skipStatic));
-            cacheManager.cacheObject(cacheKey, notFinalFields);
-            return notFinalFields;
-        });
-    }
-
-    /**
      * Returns all the not final fields.
      * @param clazz the class containing fields.
      * @param skipStatic if true the static fields are skipped.

--- a/src/test/java/com/hotels/beans/sample/FromFoo.java
+++ b/src/test/java/com/hotels/beans/sample/FromFoo.java
@@ -30,8 +30,8 @@ import lombok.Setter;
 @Getter
 @Setter
 public class FromFoo {
-    private String name;
-    private final BigInteger id;
+    private final String name;
+    private BigInteger id;
     private final List<FromSubFoo> nestedObjectList;
     private final List<String> list;
     private final FromSubFoo nestedObject;

--- a/src/test/java/com/hotels/beans/sample/immutable/ImmutableToFoo.java
+++ b/src/test/java/com/hotels/beans/sample/immutable/ImmutableToFoo.java
@@ -30,7 +30,6 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class ImmutableToFoo {
-    @NotNull
     private final String name;
     @NotNull
     private final BigInteger id;

--- a/src/test/java/com/hotels/beans/sample/immutable/ImmutableToSubFoo.java
+++ b/src/test/java/com/hotels/beans/sample/immutable/ImmutableToSubFoo.java
@@ -19,8 +19,6 @@ package com.hotels.beans.sample.immutable;
 import java.util.List;
 import java.util.Map;
 
-import javax.validation.constraints.NotNull;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
@@ -32,7 +30,6 @@ import lombok.ToString;
 @Getter
 @ToString
 public class ImmutableToSubFoo {
-    @NotNull
     private final String name;
     private final int[] phoneNumbers;
     private final Map<String, String> sampleMap;

--- a/src/test/java/com/hotels/beans/transformer/AbstractTransformerTest.java
+++ b/src/test/java/com/hotels/beans/transformer/AbstractTransformerTest.java
@@ -16,111 +16,127 @@
 
 package com.hotels.beans.transformer;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 
-import org.junit.Before;
-import org.junit.Test;
+import static com.hotels.beans.constant.ClassType.IMMUTABLE;
 
-import com.hotels.beans.model.FieldMapping;
-import com.hotels.beans.model.FieldTransformer;
-import com.hotels.beans.utils.ReflectionUtils;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.BeforeClass;
+
+import com.hotels.beans.sample.FromFoo;
+import com.hotels.beans.sample.FromFooAdvFields;
+import com.hotels.beans.sample.FromFooSimple;
+import com.hotels.beans.sample.FromFooSubClass;
+import com.hotels.beans.sample.FromFooWithPrimitiveFields;
+import com.hotels.beans.sample.FromSubFoo;
 
 /**
- * Unit test for class: {@link AbstractTransformer}.
+ * Unit test for {@link Transformer}.
  */
 public class AbstractTransformerTest {
-    private static final String SOURCE_FIELD_NAME = "sourceFieldName";
-    private static final String SOURCE_FIELD_NAME_2 = "sourceFieldName2";
-    private static final String DEST_FIELD_NAME = "destFieldName";
-    private static final String TRANSFORMER_SETTINGS_FIELD_NAME = "settings";
-    private static final ReflectionUtils REFLECTION_UTILS = new ReflectionUtils();
+    protected static final BigInteger ID = new BigInteger("1234");
+    protected static final String NAME = "Goofy";
+    protected static FromFoo fromFoo;
+    protected static FromFoo fromFooWithNullProperties;
+    protected static FromFooSimple fromFooSimple;
+    protected static FromFooWithPrimitiveFields fromFooWithPrimitiveFields;
+    protected static List<FromSubFoo> fromSubFooList;
+    protected static List<String> sourceFooSimpleList;
+    protected static FromSubFoo fromSubFoo;
+    protected static FromFooSubClass fromFooSubClass;
+    protected static FromFooAdvFields fromFooAdvFields;
+    protected static final int AGE = 34;
+    protected static final String AGE_FIELD_NAME = "age";
+    protected static final String DEST_FIELD_NAME = "destFieldName";
+    protected static final String CONSTRUCTOR_PARAMETER_NAME = "constructorParameterName";
+    protected static final String REFLECTION_UTILS_FIELD_NAME = "reflectionUtils";
+
+    private static final String ITEM_1 = "donald";
+    private static final String ITEM_2 = "duck";
+    private static final String SURNAME = "surname";
+    private static final int PHONE = 123;
+    private static final String INDEX_NUMBER = null;
+    private static final boolean CHECK = true;
+    private static final BigDecimal AMOUNT = new BigDecimal(10);
+    private static final String SUB_FOO_NAME = "Smith";
+    private static final int[] SUB_FOO_PHONE_NUMBERS = {12345, 6892, 10873};
+    private static final Map<String, String> SUB_FOO_SAMPLE_MAP = new HashMap<>();
+    private static final Map<String, List<String>> SUB_FOO_COMPLEX_MAP = new HashMap<>();
+    private static final Map<String, Map<String, String>> SUB_FOO_VERY_COMPLEX_MAP = new HashMap<>();
 
     /**
-     * The class to be tested.
+     * Initializes the arguments and objects.
      */
-    private AbstractTransformer underTest;
-
-    /**
-     * Initialized mocks.
-     */
-    @Before
-    public void beforeMethod() {
-        underTest = new TransformerImpl();
-        initMocks(this);
+    @BeforeClass
+    public static void beforeClass() {
+        initObjects();
     }
 
     /**
-     * Test that is possible to remove a field mapping for a given field.
+     * Create an instance of two objects: one without custom annotation and another one with custom annotations then execute the copy into a specular immutable object.
      */
-    @Test
-    public void testRemoveFieldMappingWorksProperly() {
-        //GIVEN
-        Transformer beanTransformer = underTest.withFieldMapping(new FieldMapping(SOURCE_FIELD_NAME, DEST_FIELD_NAME));
-
-        //WHEN
-        beanTransformer.removeFieldMapping(DEST_FIELD_NAME);
-        TransformerSettings transformerSettings = (TransformerSettings) REFLECTION_UTILS.getFieldValue(beanTransformer, TRANSFORMER_SETTINGS_FIELD_NAME, TransformerSettings.class);
-
-        //THEN
-        assertFalse(transformerSettings.getFieldsNameMapping().containsKey(DEST_FIELD_NAME));
+    private static void initObjects() {
+        SUB_FOO_SAMPLE_MAP.put(ITEM_1, ITEM_2);
+        SUB_FOO_COMPLEX_MAP.put(ITEM_1, singletonList(ITEM_2));
+        SUB_FOO_VERY_COMPLEX_MAP.put(ITEM_1, SUB_FOO_SAMPLE_MAP);
+        fromSubFoo = new FromSubFoo(SUB_FOO_NAME, SUB_FOO_PHONE_NUMBERS, SUB_FOO_SAMPLE_MAP, SUB_FOO_COMPLEX_MAP, SUB_FOO_VERY_COMPLEX_MAP);
+        fromSubFooList = singletonList(fromSubFoo);
+        sourceFooSimpleList = asList(ITEM_1, ITEM_2);
+        fromFoo = createFromFoo(fromSubFoo);
+        fromFooWithNullProperties = createFromFoo(null);
+        fromFooSimple = createFromFooSimple();
+        fromFooWithPrimitiveFields = createFromFooWithPrimitiveFields();
+        fromFooSubClass = createFromFooSubClass();
+        fromFooAdvFields = createFromFooAdvFields();
     }
 
     /**
-     * Test that the method {@code removeFieldMapping} raises an {@link IllegalArgumentException} if the parameter is null.
+     * Creates a {@link FromFoo} instance.
+     * @param fromSubFoo the {@link FromSubFoo} instance
+     * @return the {@link FromFoo} instance.
      */
-    @Test(expected = IllegalArgumentException.class)
-    public void testRemoveFieldMappingRaisesExceptionIfItsCalledWithNullParam() {
-        //GIVEN
-        Transformer beanTransformer = underTest.withFieldMapping(new FieldMapping(SOURCE_FIELD_NAME, DEST_FIELD_NAME));
-
-        //WHEN
-        beanTransformer.removeFieldMapping(null);
+    private static FromFoo createFromFoo(final FromSubFoo fromSubFoo) {
+        return new FromFoo(NAME, ID, fromSubFooList, sourceFooSimpleList, fromSubFoo);
     }
 
     /**
-     * Test that is possible to remove all the fields mappings defined.
+     * Creates a {@link FromFooSimple} instance.
+     * @return the {@link FromFooSimple} instance.
      */
-    @Test
-    public void testResetFieldsMappingWorksProperly() {
-        //GIVEN
-        Transformer beanTransformer = underTest
-                .withFieldMapping(new FieldMapping(SOURCE_FIELD_NAME, DEST_FIELD_NAME), new FieldMapping(SOURCE_FIELD_NAME_2, DEST_FIELD_NAME));
+    private static FromFooSimple createFromFooSimple() {
+        return new FromFooSimple(NAME, ID);
+    }
 
-        //WHEN
-        beanTransformer.resetFieldsMapping();
-        TransformerSettings transformerSettings = (TransformerSettings) REFLECTION_UTILS.getFieldValue(beanTransformer, TRANSFORMER_SETTINGS_FIELD_NAME, TransformerSettings.class);
 
-        //THEN
-        assertTrue(transformerSettings.getFieldsNameMapping().isEmpty());
+    /**
+     * Creates a {@link FromFooWithPrimitiveFields} instance.
+     * @return the {@link FromFooWithPrimitiveFields} instance.
+     */
+    private static FromFooWithPrimitiveFields createFromFooWithPrimitiveFields() {
+        return new FromFooWithPrimitiveFields(NAME, ID.intValue(), AGE, fromSubFooList, sourceFooSimpleList, fromSubFoo);
     }
 
     /**
-     * Test that is possible to remove a field transformer for a given field.
+     * Creates a {@link FromFooSubClass} instance.
+     * @return the {@link FromFooSubClass} instance.
      */
-    @Test
-    public void testRemoveFieldTransformerWorksProperly() {
-        //GIVEN
-        Transformer beanTransformer = underTest.withFieldTransformer(new FieldTransformer<>(DEST_FIELD_NAME, val -> val));
-
-        //WHEN
-        beanTransformer.removeFieldTransformer(DEST_FIELD_NAME);
-        TransformerSettings transformerSettings = (TransformerSettings) REFLECTION_UTILS.getFieldValue(beanTransformer, TRANSFORMER_SETTINGS_FIELD_NAME, TransformerSettings.class);
-
-        //THEN
-        assertFalse(transformerSettings.getFieldsTransformers().containsKey(DEST_FIELD_NAME));
+    private static FromFooSubClass createFromFooSubClass() {
+        return new FromFooSubClass(fromFoo.getName(), fromFoo.getId(), fromFoo.getNestedObjectList(), fromFoo.getList(), fromFoo.getNestedObject(), SURNAME, PHONE, CHECK, AMOUNT);
     }
 
     /**
-     * Test that the method {@code removeFieldTransformer} raises an {@link IllegalArgumentException} if the parameter is null.
+     * Creates a {@link FromFooAdvFields} instance.
+     * @return the {@link FromFooAdvFields} instance.
      */
-    @Test(expected = IllegalArgumentException.class)
-    public void testRemoveFieldTransformerRaisesExceptionIfItsCalledWithNullParam() {
-        //GIVEN
-        Transformer beanTransformer = underTest.withFieldTransformer(new FieldTransformer<>(DEST_FIELD_NAME, val -> val));
-
-        //WHEN
-        beanTransformer.removeFieldTransformer(null);
+    private static FromFooAdvFields createFromFooAdvFields() {
+        return new FromFooAdvFields(Optional.of(NAME), Optional.of(AGE), INDEX_NUMBER, IMMUTABLE, Locale.ENGLISH.getLanguage());
     }
 }

--- a/src/test/java/com/hotels/beans/transformer/AbstractTransformerTest.java
+++ b/src/test/java/com/hotels/beans/transformer/AbstractTransformerTest.java
@@ -34,7 +34,7 @@ public class AbstractTransformerTest {
     private static final String SOURCE_FIELD_NAME = "sourceFieldName";
     private static final String SOURCE_FIELD_NAME_2 = "sourceFieldName2";
     private static final String DEST_FIELD_NAME = "destFieldName";
-    private static final String TRANSFORMER_SETTINGS_FIELD_NAME = "transformerSettings";
+    private static final String TRANSFORMER_SETTINGS_FIELD_NAME = "settings";
     private static final ReflectionUtils REFLECTION_UTILS = new ReflectionUtils();
 
     /**

--- a/src/test/java/com/hotels/beans/transformer/ImmutableObjectTransformationTest.java
+++ b/src/test/java/com/hotels/beans/transformer/ImmutableObjectTransformationTest.java
@@ -1,0 +1,486 @@
+/**
+ * Copyright (C) 2019 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hotels.beans.transformer;
+
+import static java.lang.String.format;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Locale;
+import java.util.stream.IntStream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+
+import com.hotels.beans.annotation.ConstructorArg;
+import com.hotels.beans.cache.CacheManager;
+import com.hotels.beans.error.InvalidBeanException;
+import com.hotels.beans.model.FieldMapping;
+import com.hotels.beans.model.FieldTransformer;
+import com.hotels.beans.sample.FromFoo;
+import com.hotels.beans.sample.FromFooSimple;
+import com.hotels.beans.sample.immutable.ImmutableFlatToFoo;
+import com.hotels.beans.sample.immutable.ImmutableToFoo;
+import com.hotels.beans.sample.immutable.ImmutableToFooAdvFields;
+import com.hotels.beans.sample.immutable.ImmutableToFooCustomAnnotation;
+import com.hotels.beans.sample.immutable.ImmutableToFooDiffFields;
+import com.hotels.beans.sample.immutable.ImmutableToFooInvalid;
+import com.hotels.beans.sample.immutable.ImmutableToFooMissingCustomAnnotation;
+import com.hotels.beans.sample.immutable.ImmutableToFooNoConstructors;
+import com.hotels.beans.sample.immutable.ImmutableToFooNotExistingFields;
+import com.hotels.beans.sample.immutable.ImmutableToFooSimple;
+import com.hotels.beans.sample.immutable.ImmutableToFooSimpleWrongTypes;
+import com.hotels.beans.sample.immutable.ImmutableToFooSubClass;
+import com.hotels.beans.sample.mutable.MutableToFooSubClass;
+import com.hotels.beans.utils.ReflectionUtils;
+
+/**
+ * Unit test for all {@link Transformer} functions related to Immutable Java Beans.
+ */
+public class ImmutableObjectTransformationTest extends AbstractTransformerTest {
+    private static final int TOTAL_ADV_CLASS_FIELDS = 5;
+    private static final String GET_DEST_FIELD_NAME_METHOD_NAME = "getDestFieldName";
+    private static final String GET_CONSTRUCTOR_VALUES_FROM_FIELDS_METHOD_NAME = "getConstructorValuesFromFields";
+
+    /**
+     * The class to be tested.
+     */
+    @InjectMocks
+    private TransformerImpl underTest;
+
+    /**
+     * Initialized mocks.
+     */
+    @Before
+    public void beforeMethod() {
+        initMocks(this);
+    }
+
+    /**
+     * Test that immutable beans without constructor arguments parameter annotated with: @ConstructorArg {@link com.hotels.beans.annotation.ConstructorArg} are correctly copied.
+     */
+    @Test
+    public void testBeanWithoutCustomAnnotationIsCorrectlyCopied() {
+        //GIVEN
+
+        //WHEN
+        ImmutableToFoo actual = underTest.transform(fromFoo, ImmutableToFoo.class);
+
+        //THEN
+        assertThat(actual, sameBeanAs(fromFoo));
+    }
+
+    /**
+     * Test that, in case a destination object field is contained into a nested object of the source field, defining a composite {@link FieldMapping} the field is correctly
+     * valorized.
+     */
+    @Test
+    public void testTransformationWithCompositeFieldNameMappingIsWorkingAsExpected() {
+        //GIVEN
+        FieldMapping phoneNumbersMapping = new FieldMapping("nestedObject.phoneNumbers", "phoneNumbers");
+
+        //WHEN
+        ImmutableFlatToFoo actual = underTest.withFieldMapping(phoneNumbersMapping).transform(fromFoo, ImmutableFlatToFoo.class);
+
+        //THEN
+        assertEquals(fromFoo.getName(), actual.getName());
+        assertEquals(fromFoo.getId(), actual.getId());
+        assertEquals(fromFoo.getNestedObject().getPhoneNumbers(), actual.getPhoneNumbers());
+        underTest.resetFieldsMapping();
+    }
+
+    /**
+     * Test that, in case a destination object field is contained into a nested object of the source field, defining a composite {@link FieldMapping} the field is correctly
+     * valorized even if some of them are null.
+     */
+    @Test
+    public void testTransformationWithCompositeFieldNameWorksEvenWithNullObjects() {
+        //GIVEN
+        FieldMapping phoneNumbersMapping = new FieldMapping("nestedObject.phoneNumbers", "phoneNumbers");
+
+        //WHEN
+        ImmutableFlatToFoo actual = underTest.withFieldMapping(phoneNumbersMapping).transform(fromFooWithNullProperties, ImmutableFlatToFoo.class);
+
+        //THEN
+        assertEquals(fromFooWithNullProperties.getName(), actual.getName());
+        assertEquals(fromFooWithNullProperties.getId(), actual.getId());
+        assertNull(actual.getPhoneNumbers());
+        underTest.resetFieldsMapping();
+    }
+
+    /**
+     * Test that immutable beans without custom field mapping.
+     */
+    @Test
+    public void testBeanWithEmptyFieldMappingIsCorrectlyCopied() {
+        //GIVEN
+
+        //WHEN
+        ImmutableToFoo actual = underTest.withFieldMapping().transform(fromFoo, ImmutableToFoo.class);
+
+        //THEN
+        assertThat(actual, sameBeanAs(fromFoo));
+    }
+
+    /**
+     * Test that immutable beans without custom field mapping.
+     */
+    @Test
+    public void testBeanWithEmptyFieldTransformerIsCorrectlyCopied() {
+        //GIVEN
+
+        //WHEN
+        ImmutableToFoo actual = underTest.withFieldMapping().transform(fromFoo, ImmutableToFoo.class);
+
+        //THEN
+        assertThat(actual, sameBeanAs(fromFoo));
+    }
+
+    /**
+     * Test that immutable beans with constructor arguments parameter annotated with: @ConstructorArg {@link com.hotels.beans.annotation.ConstructorArg} are correctly copied.
+     */
+    @Test
+    public void testBeanWithCustomAnnotationIsCorrectlyCopied() {
+        //GIVEN
+
+        //WHEN
+        ImmutableToFooCustomAnnotation actual = underTest.transform(fromFoo, ImmutableToFooCustomAnnotation.class);
+
+        //THEN
+        assertThat(actual, sameBeanAs(fromFoo));
+    }
+
+    /**
+     * Test that an exception is thrown if the constructor invocation throws exception.
+     */
+    @Test(expected = InvalidBeanException.class)
+    public void testTransformThrowsExceptionIfTheConstructorInvocationThrowsException() {
+        //GIVEN
+        FromFoo actual = new FromFoo(NAME, ID, null, null, null);
+
+        //WHEN
+        underTest.transform(actual, ImmutableToFooCustomAnnotation.class);
+    }
+
+    /**
+     * Test that an exception is thrown if no constructors are defined.
+     */
+    @Test(expected = InvalidBeanException.class)
+    public void testTransformThrowsExceptionWhenParameterAreNull() {
+        //GIVEN
+        FromFoo actual = new FromFoo(NAME, ID, null, null, null);
+
+        //WHEN
+        underTest.transform(actual, ImmutableToFooNoConstructors.class);
+    }
+
+
+    /**
+     * Test that an exception is thrown if there the constructor args parameters have a different order for the mutable bean object.
+     */
+    @Test(expected = InvalidBeanException.class)
+    public void testTransformThrowsExceptionWhenImmutableBeanHasAWrongConstructor() {
+        //GIVEN
+
+        //WHEN
+        underTest.transform(fromFoo, ImmutableToFooInvalid.class);
+    }
+
+    /**
+     * Test that an exception is thrown if the destination object don't met the constraints.
+     */
+    @Test(expected = InvalidBeanException.class)
+    public void testTransformThrowsExceptionIfTheDestinationObjectValuesAreNotValid() {
+        //GIVEN
+        fromFoo.setId(null);
+
+        //WHEN
+        underTest.transform(fromFoo, ImmutableToFoo.class);
+
+        // THEN
+        fromFoo.setId(ID);
+    }
+
+    /**
+     * Test that no exception is thrown if the destination object don't met the constraints and the validation is disabled.
+     */
+    @Test
+    public void testTransformThrowsNoExceptionIfTheDestinationObjectValuesAreNotValidAndTheValidationIsDisabled() {
+        //GIVEN
+        fromFoo.setId(null);
+        underTest.setValidationDisabled(true);
+
+        //WHEN
+        ImmutableToFoo actual = underTest.transform(fromFoo, ImmutableToFoo.class);
+
+        // THEN
+        assertThat(actual, sameBeanAs(fromFoo));
+        fromFoo.setId(ID);
+        underTest.setValidationDisabled(false);
+    }
+
+    /**
+     * Test that bean that extends another class are correctly copied.
+     */
+    @Test
+    public void testBeanWithoutCustomAnnotationAndWithSuperclassIsCorrectlyCopied() {
+        //GIVEN
+
+        //WHEN
+        ImmutableToFooSubClass actual = underTest.transform(fromFooSubClass, ImmutableToFooSubClass.class);
+
+        //THEN
+        assertThat(actual, sameBeanAs(fromFooSubClass));
+    }
+
+    /**
+     * Test that bean containing final fields (with different field names) are correctly copied.
+     */
+    @Test
+    public void testImmutableBeanWithDifferentFieldNamesIsCorrectlyCopied() {
+        //GIVEN
+
+        //WHEN
+        final Transformer beanTransformer = underTest.withFieldMapping(new FieldMapping("id", "identifier"));
+        ImmutableToFooDiffFields actual = beanTransformer.transform(fromFoo, ImmutableToFooDiffFields.class);
+
+        //THEN
+        assertThat(actual, hasProperty("name", equalTo(actual.getName())));
+        assertThat(actual, hasProperty("identifier", equalTo(fromFoo.getId())));
+        assertEquals(actual.getList(), fromFoo.getList());
+        IntStream.range(0, actual.getNestedObjectList().size())
+                .forEach(i -> assertThat(actual.getNestedObjectList().get(i), sameBeanAs(fromFoo.getNestedObjectList().get(i))));
+        assertThat(actual.getNestedObject(), sameBeanAs(fromFoo.getNestedObject()));
+    }
+
+    /**
+     * Test that bean containing advanced final fields are correctly copied.
+     */
+    @Test
+    public void testImmutableBeanWithAdvancedFieldsIsCorrectlyCopied() {
+        //GIVEN
+
+        //WHEN
+        final Transformer beanTransformer = underTest
+                .withFieldMapping(new FieldMapping("id", "identifier"))
+                .withFieldTransformer(new FieldTransformer<>("locale", Locale::forLanguageTag));
+        ImmutableToFooAdvFields actual = beanTransformer.transform(fromFooAdvFields, ImmutableToFooAdvFields.class);
+
+        //THEN
+        assertNotNull(actual.getName());
+        assertTrue(actual.getName().isPresent());
+        assertEquals(fromFooAdvFields.getName().get(), actual.getName().get());
+        assertEquals(fromFooAdvFields.getAge().get(), actual.getAge());
+        assertEquals(fromFooAdvFields.getClassType(), actual.getClassType());
+        assertEquals(fromFooAdvFields.getLocale(), actual.getLocale().getLanguage());
+    }
+
+    /**
+     * Test that immutable bean containing a constructor with some field not annotated with
+     * {@link com.hotels.beans.annotation.ConstructorArg} is correctly copied.
+     */
+    @Test
+    public void testImmutableBeanWithMissingConstructorArgIsCorrectlyCopied() {
+        //GIVEN
+
+        //WHEN
+        ImmutableToFooMissingCustomAnnotation actual = underTest.withFieldTransformer().transform(fromFooWithPrimitiveFields, ImmutableToFooMissingCustomAnnotation.class);
+
+        //THEN
+        assertNotNull(actual);
+        assertEquals(fromFooWithPrimitiveFields.getName(), actual.getName());
+    }
+
+    /**
+     * Test that method: {@code getDestFieldName} retrieves the param name from the {@link ConstructorArg} if it is not provided from jvm directly.
+     */
+    @Test
+    public void testGetDestFieldNameIsRetrievedFromConstructorArgIfTheParamNameIsNotProvidedFromJVM() throws Exception {
+        //GIVEN
+        String declaringClassName = ImmutableToFoo.class.getName();
+        // Parameter mock setup
+        Parameter constructorParameter = mock(Parameter.class);
+        when(constructorParameter.getName()).thenReturn(CONSTRUCTOR_PARAMETER_NAME);
+
+        // CacheManager mock setup
+        initGetDestFieldNameTestMock(declaringClassName, constructorParameter);
+        Method getDestFieldNameMethod = underTest.getClass().getDeclaredMethod(GET_DEST_FIELD_NAME_METHOD_NAME, Parameter.class, String.class);
+        getDestFieldNameMethod.setAccessible(true);
+
+        //WHEN
+        String actual = (String) getDestFieldNameMethod.invoke(underTest, constructorParameter, declaringClassName);
+
+        //THEN
+        assertEquals(DEST_FIELD_NAME, actual);
+
+        // restore modified objects
+        restoreObjects(getDestFieldNameMethod);
+    }
+
+    /**
+     * Test that the method: {@code getConstructorValuesFromFields} works properly.
+     */
+    @Test
+    public void testGetConstructorValuesFromFieldsWorksProperly() throws Exception {
+        //GIVEN
+        underTest.withFieldTransformer(new FieldTransformer<>("locale", Locale::forLanguageTag));
+
+        //WHEN
+        final Method getConstructorValuesFromFieldsMethod =
+                underTest.getClass().getDeclaredMethod(GET_CONSTRUCTOR_VALUES_FROM_FIELDS_METHOD_NAME, Object.class, Class.class, String.class);
+        getConstructorValuesFromFieldsMethod.setAccessible(true);
+        Object[] actual = (Object[]) getConstructorValuesFromFieldsMethod.invoke(underTest, fromFooAdvFields, ImmutableToFooAdvFields.class, "");
+
+        //THEN
+        assertNotNull(actual);
+        assertEquals(TOTAL_ADV_CLASS_FIELDS, actual.length);
+
+        // restore modified objects
+        restoreObjects(getConstructorValuesFromFieldsMethod);
+    }
+
+    /**
+     * Test that method: {@code getDestFieldName} returns null if the constructor's parameter name is not provided from jvm directly and the {@link ConstructorArg} is not defined.
+     */
+    @Test
+    public void testGetDestFieldNameReturnsNullIfConstructorParamHasNoNameProvidedFromJVMAndNoConstructorArgIsDefined() throws Exception {
+        //GIVEN
+        String declaringClassName = ImmutableToFoo.class.getName();
+        // Parameter mock setup
+        Parameter constructorParameter = mock(Parameter.class);
+        when(constructorParameter.getName()).thenReturn(null);
+
+        // CacheManager mock setup
+        initGetDestFieldNameTestMock(declaringClassName, constructorParameter);
+        Method getDestFieldNameMethod = underTest.getClass().getDeclaredMethod(GET_DEST_FIELD_NAME_METHOD_NAME, Parameter.class, String.class);
+        getDestFieldNameMethod.setAccessible(true);
+
+        //WHEN
+        String actual = (String) getDestFieldNameMethod.invoke(underTest, constructorParameter, declaringClassName);
+
+        //THEN
+        assertEquals(DEST_FIELD_NAME, actual);
+
+        // restore modified objects
+        restoreObjects(getDestFieldNameMethod);
+    }
+
+    /**
+     * Test that a meaningful exception is returned when a constructor is invoked with wrong arguments.
+     */
+    @Test
+    public void testTransformationReturnsAMeaningfulException() {
+        //GIVEN
+        Class<ImmutableToFooSimpleWrongTypes> targetClass = ImmutableToFooSimpleWrongTypes.class;
+        final String expectedExceptionMessageFormat =
+                "Constructor invoked with arguments. Expected: public %s(java.lang.Integer,java.lang.String); Found: %s(java.math.BigInteger,java.lang.String). "
+                        +  "Double check that each %s's field have the same type and name than the source object: %s otherwise specify a transformer configuration.";
+        String targetClassName = targetClass.getCanonicalName();
+        String expectedExceptionMessage =
+                format(expectedExceptionMessageFormat, targetClassName, targetClassName, targetClass.getSimpleName(), fromFooSimple.getClass().getCanonicalName());
+
+        //WHEN
+        Exception raisedException = null;
+        try {
+            underTest.transform(fromFooSimple, targetClass);
+        } catch (final Exception e) {
+            raisedException = e;
+        }
+
+        //THEN
+        assertNotNull(raisedException);
+        assertEquals(InvalidBeanException.class, raisedException.getClass());
+        assertEquals(expectedExceptionMessage, raisedException.getMessage());
+    }
+
+    /**
+     * Test transformation on an existing bean is correctly copied.
+     */
+    @Test
+    public void testTransformationOnAnExistingDestinationWorksProperly() {
+        //GIVEN
+        MutableToFooSubClass mutableToFoo = new MutableToFooSubClass();
+        ImmutableToFooSimple immutableToFoo = new ImmutableToFooSimple(null, null);
+
+        //WHEN
+        underTest.transform(fromFooSubClass, mutableToFoo);
+        underTest.transform(fromFooSimple, immutableToFoo);
+
+        //THEN
+        assertThat(mutableToFoo, sameBeanAs(fromFooSubClass));
+        assertThat(immutableToFoo, sameBeanAs(fromFooSimple));
+    }
+
+    /**
+     * Test that a bean containing a field not existing in the source object, but with a transformer function defined for such object is correctly copied.
+     */
+    @Test
+    public void testThatAnyTypeOfBeanContainsANotExistingFieldInTheSourceObjectIsCorrectlyCopiedThroughTransformerFunctions() {
+        //GIVEN
+        FromFooSimple fromFooSimple = new FromFooSimple(NAME, ID);
+        FieldTransformer<Object, Integer> ageFieldTransformer = new FieldTransformer<>(AGE_FIELD_NAME, val -> AGE);
+
+        //WHEN
+        underTest.withFieldTransformer(ageFieldTransformer);
+        ImmutableToFooNotExistingFields immutableObjectBean = underTest.transform(fromFooSimple, ImmutableToFooNotExistingFields.class);
+
+        //THEN
+        assertThat(immutableObjectBean, hasProperty(AGE_FIELD_NAME, equalTo(AGE)));
+    }
+
+    /**
+     * Initializes the mocks required for testing method: {@code getDestFieldName}.
+     * @param declaringClassName the declaring class name
+     * @param constructorParameter the constructor parameter
+     */
+    private void initGetDestFieldNameTestMock(final String declaringClassName, final Parameter constructorParameter) {
+        CacheManager cacheManager = mock(CacheManager.class);
+        String cacheKey = "DestFieldName-" + declaringClassName + "-" + CONSTRUCTOR_PARAMETER_NAME;
+        when(cacheManager.getFromCache(cacheKey, String.class)).thenReturn(null);
+        // ConstructorArg mock setup
+        ConstructorArg constructorArg = mock(ConstructorArg.class);
+        when(constructorArg.value()).thenReturn(DEST_FIELD_NAME);
+        // ReflectionUtils mock setup
+        ReflectionUtils reflectionUtils = mock(ReflectionUtils.class);
+        when(reflectionUtils.getParameterAnnotation(constructorParameter, ConstructorArg.class, declaringClassName)).thenReturn(constructorArg);
+        setField(underTest, REFLECTION_UTILS_FIELD_NAME, reflectionUtils);
+    }
+
+    /**
+     * Restored the initial object status before testing method: {@code getDestFieldName}.
+     */
+    private void restoreObjects(final Method getDestFieldNameMethod) {
+        getDestFieldNameMethod.setAccessible(false);
+        setField(underTest, REFLECTION_UTILS_FIELD_NAME, new ReflectionUtils());
+    }
+
+}

--- a/src/test/java/com/hotels/beans/transformer/ImmutableObjectTransformationTest.java
+++ b/src/test/java/com/hotels/beans/transformer/ImmutableObjectTransformationTest.java
@@ -60,7 +60,6 @@ import com.hotels.beans.sample.immutable.ImmutableToFooNotExistingFields;
 import com.hotels.beans.sample.immutable.ImmutableToFooSimple;
 import com.hotels.beans.sample.immutable.ImmutableToFooSimpleWrongTypes;
 import com.hotels.beans.sample.immutable.ImmutableToFooSubClass;
-import com.hotels.beans.sample.mutable.MutableToFooSubClass;
 import com.hotels.beans.utils.ReflectionUtils;
 
 /**
@@ -428,15 +427,12 @@ public class ImmutableObjectTransformationTest extends AbstractTransformerTest {
     @Test
     public void testTransformationOnAnExistingDestinationWorksProperly() {
         //GIVEN
-        MutableToFooSubClass mutableToFoo = new MutableToFooSubClass();
         ImmutableToFooSimple immutableToFoo = new ImmutableToFooSimple(null, null);
 
         //WHEN
-        underTest.transform(fromFooSubClass, mutableToFoo);
         underTest.transform(fromFooSimple, immutableToFoo);
 
         //THEN
-        assertThat(mutableToFoo, sameBeanAs(fromFooSubClass));
         assertThat(immutableToFoo, sameBeanAs(fromFooSimple));
     }
 

--- a/src/test/java/com/hotels/beans/transformer/MixedObjectTransformationTest.java
+++ b/src/test/java/com/hotels/beans/transformer/MixedObjectTransformationTest.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright (C) 2019 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hotels.beans.transformer;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs;
+
+import java.math.BigInteger;
+import java.util.stream.IntStream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+
+import com.hotels.beans.error.MissingFieldException;
+import com.hotels.beans.model.FieldMapping;
+import com.hotels.beans.model.FieldTransformer;
+import com.hotels.beans.sample.FromFooSimple;
+import com.hotels.beans.sample.mixed.MixedToFoo;
+import com.hotels.beans.sample.mixed.MixedToFooDiffFields;
+import com.hotels.beans.sample.mixed.MixedToFooMissingAllArgsConstructor;
+import com.hotels.beans.sample.mixed.MixedToFooMissingField;
+import com.hotels.beans.sample.mixed.MixedToFooNotExistingFields;
+
+/**
+ * Unit test for all {@link Transformer} functions related to Mixed type Java Beans.
+ */
+public class MixedObjectTransformationTest extends AbstractTransformerTest {
+    /**
+     * The class to be tested.
+     */
+    @InjectMocks
+    private TransformerImpl underTest;
+
+    /**
+     * Initialized mocks.
+     */
+    @Before
+    public void beforeMethod() {
+        initMocks(this);
+    }
+
+    /**
+     * Test that a Mixed bean with a constructor containing the final field only is correctly copied.
+     */
+    @Test
+    public void testMixedBeanWithoutAllArgsConstructorIsCorrectlyCopied() {
+        //GIVEN
+
+        //WHEN
+        MixedToFooMissingAllArgsConstructor actual = underTest.transform(fromFoo, MixedToFooMissingAllArgsConstructor.class);
+
+        //THEN
+        assertThat(actual, sameBeanAs(fromFoo));
+    }
+
+    /**
+     * Test that bean containing both final fields and not are correctly copied.
+     */
+    @Test
+    public void testMixedBeanIsCorrectlyCopied() {
+        //GIVEN
+
+        //WHEN
+        MixedToFoo actual = underTest.transform(fromFoo, MixedToFoo.class);
+
+        //THEN
+        assertThat(actual, sameBeanAs(fromFoo));
+    }
+
+    /**
+     * Test that bean containing both final fields (with different names) and not are correctly copied.
+     */
+    @Test
+    public void testMixedBeanWithDifferentFieldNamesIsCorrectlyCopied() {
+        //GIVEN
+
+        //WHEN
+        final Transformer beanTransformer = underTest.withFieldMapping(new FieldMapping("id", "identifier"));
+        MixedToFooDiffFields actual = beanTransformer.transform(fromFoo, MixedToFooDiffFields.class);
+
+        //THEN
+        assertThat(actual, hasProperty("name", equalTo(actual.getName())));
+        assertThat(actual, hasProperty("identifier", equalTo(fromFoo.getId())));
+        assertEquals(actual.getList(), fromFoo.getList());
+        IntStream.range(0, actual.getNestedObjectList().size())
+                .forEach(i -> assertThat(actual.getNestedObjectList().get(i), sameBeanAs(fromFoo.getNestedObjectList().get(i))));
+        assertThat(actual.getNestedObject(), sameBeanAs(fromFoo.getNestedObject()));
+    }
+
+    /**
+     * Test that bean containing both final fields (with different names) and not are correctly copied through field transformer.
+     */
+    @Test
+    public void testMixedBeanWithDifferentFieldNamesIsCorrectlyCopiedThroughFieldTransformer() {
+        //GIVEN
+        /* Extended declaration.
+         * Function<BigInteger, BigInteger> idTransformer = value -> value.negate();
+         * FieldTransformer<BigInteger, BigInteger> fieldTransformer = new FieldTransformer<>("identifier", idTransformer);
+         */
+        FieldTransformer<BigInteger, BigInteger> fieldTransformer = new FieldTransformer<>("identifier", BigInteger::negate);
+
+        //WHEN
+        underTest.withFieldMapping(new FieldMapping("id", "identifier")).withFieldTransformer(fieldTransformer);
+        MixedToFooDiffFields actual = underTest.transform(fromFoo, MixedToFooDiffFields.class);
+
+        //THEN
+        assertThat(actual, hasProperty("name", equalTo(actual.getName())));
+        assertThat(actual, hasProperty("identifier", equalTo(fromFoo.getId().negate())));
+        assertEquals(actual.getList(), fromFoo.getList());
+        IntStream.range(0, actual.getNestedObjectList().size())
+                .forEach(i -> assertThat(actual.getNestedObjectList().get(i), sameBeanAs(fromFoo.getNestedObjectList().get(i))));
+        assertThat(actual.getNestedObject(), sameBeanAs(fromFoo.getNestedObject()));
+    }
+
+    /**
+     * Test that the copy method sets the default value when the source object does not contain a required field.
+     */
+    @Test
+    public void testMixedBeanWithMissingFieldsReturnsTheDefaultValueWhenTheSourceObjectDoesNotContainARequiredField() {
+        //GIVEN
+        underTest.setDefaultValueForMissingField(true);
+
+        //WHEN
+        MixedToFooMissingField actual = underTest.transform(fromFoo, MixedToFooMissingField.class);
+
+        assertNull(actual.getFooField());
+        underTest.setDefaultValueForMissingField(false);
+    }
+
+    /**
+     * Test that the copy method raises an exception when the source object does not contain a required field.
+     */
+    @Test(expected = MissingFieldException.class)
+    public void testMixedBeanWithMissingFieldsThrowsMissingFieldExceptionWhenTheSourceObjectDoesNotContainARequiredField() {
+        //GIVEN
+        underTest.setDefaultValueForMissingField(false);
+
+        //WHEN
+        underTest.transform(fromFoo, MixedToFooMissingField.class);
+    }
+
+    /**
+     * Test that a bean containing a field not existing in the source object, but with a transformer function defined for such object is correctly copied.
+     */
+    @Test
+    public void testThatAnyTypeOfBeanContainsANotExistingFieldInTheSourceObjectIsCorrectlyCopiedThroughTransformerFunctions() {
+        //GIVEN
+        FromFooSimple fromFooSimple = new FromFooSimple(NAME, ID);
+        FieldTransformer<Object, Integer> ageFieldTransformer = new FieldTransformer<>(AGE_FIELD_NAME, val -> AGE);
+
+        //WHEN
+        underTest.withFieldTransformer(ageFieldTransformer);
+        MixedToFooNotExistingFields mixedObjectBean = underTest.transform(fromFooSimple, MixedToFooNotExistingFields.class);
+
+        //THEN
+        assertThat(mixedObjectBean, hasProperty(AGE_FIELD_NAME, equalTo(AGE)));
+    }
+}

--- a/src/test/java/com/hotels/beans/transformer/MixedObjectTransformationTest.java
+++ b/src/test/java/com/hotels/beans/transformer/MixedObjectTransformationTest.java
@@ -176,4 +176,19 @@ public class MixedObjectTransformationTest extends AbstractTransformerTest {
         //THEN
         assertThat(mixedObjectBean, hasProperty(AGE_FIELD_NAME, equalTo(AGE)));
     }
+
+    /**
+     * Test transformation on an existing bean is correctly copied.
+     */
+    @Test
+    public void testTransformationOnAnExistingDestinationWorksProperly() {
+        //GIVEN
+        MixedToFoo mixedToFoo = new MixedToFoo(null, null, null, null, null);
+
+        //WHEN
+        underTest.transform(fromFoo, mixedToFoo);
+
+        //THEN
+        assertThat(mixedToFoo, sameBeanAs(fromFoo));
+    }
 }

--- a/src/test/java/com/hotels/beans/transformer/MutableObjectTransformationTest.java
+++ b/src/test/java/com/hotels/beans/transformer/MutableObjectTransformationTest.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (C) 2019 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hotels.beans.transformer;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+
+import com.hotels.beans.error.InvalidBeanException;
+import com.hotels.beans.model.FieldTransformer;
+import com.hotels.beans.sample.FromFooSimple;
+import com.hotels.beans.sample.FromFooSimpleNoGetters;
+import com.hotels.beans.sample.mutable.MutableToFoo;
+import com.hotels.beans.sample.mutable.MutableToFooInvalid;
+import com.hotels.beans.sample.mutable.MutableToFooNotExistingFields;
+import com.hotels.beans.sample.mutable.MutableToFooSimpleNoSetters;
+
+/**
+ * Unit test for all {@link Transformer} functions related to Mutable type Java Beans.
+ */
+public class MutableObjectTransformationTest extends AbstractTransformerTest {
+    /**
+     * The class to be tested.
+     */
+    @InjectMocks
+    private TransformerImpl underTest;
+
+    /**
+     * Initialized mocks.
+     */
+    @Before
+    public void beforeMethod() {
+        initMocks(this);
+    }
+
+    /**
+     * Test that an exception is thrown if there is no default constructor defined for the mutable bean object.
+     */
+    @Test(expected = InvalidBeanException.class)
+    public void testTransformThrowsExceptionWhenMutableBeanHasNoDefaultConstructor() {
+        //GIVEN
+
+        //WHEN
+        underTest.transform(fromFoo, MutableToFooInvalid.class);
+    }
+
+    /**
+     * Test mutable beans are correctly copied.
+     */
+    @Test
+    public void testMutableBeanIsCorrectlyCopied() {
+        //GIVEN
+
+        //WHEN
+        MutableToFoo actual = underTest.transform(fromFoo, MutableToFoo.class);
+
+        //THEN
+        assertThat(actual, sameBeanAs(fromFoo));
+    }
+
+    /**
+     * Test that a given field transformer function is applied only to a specific field even if there are other ones with same name.
+     */
+    @Test
+    public void testFieldTransformationIsAppliedOnlyToASpecificField() {
+        //GIVEN
+        String namePrefix = "prefix-";
+        FieldTransformer<String, String> nameTransformer = new FieldTransformer<>("nestedObject.name", val -> namePrefix + val);
+
+        //WHEN
+        MutableToFoo actual = underTest
+                .withFieldTransformer(nameTransformer)
+                .transform(fromFoo, MutableToFoo.class);
+
+        //THEN
+        assertEquals(fromFoo.getName(), actual.getName());
+        assertEquals(namePrefix + fromFoo.getNestedObject().getName(), actual.getNestedObject().getName());
+        underTest.resetFieldsTransformer();
+    }
+
+    /**
+     * Test that a given field transformer function is applied to all field matching the given name when {@code flatFieldNameTransformation} is set to true.
+     */
+    @Test
+    public void testFieldTransformationIsAppliedToAllMatchingFields() {
+        //GIVEN
+        String namePrefix = "prefix-";
+        FieldTransformer<String, String> nameTransformer = new FieldTransformer<>("name", val -> namePrefix + val);
+
+        //WHEN
+        MutableToFoo actual = underTest
+                .setFlatFieldNameTransformation(true)
+                .withFieldTransformer(nameTransformer)
+                .transform(fromFoo, MutableToFoo.class);
+
+        //THEN
+        assertEquals(namePrefix + fromFoo.getName(), actual.getName());
+        assertEquals(namePrefix + fromFoo.getNestedObject().getName(), actual.getNestedObject().getName());
+        underTest.resetFieldsTransformer();
+    }
+
+    /**
+     * Test that the transformer is able to copy object even if the source object has no setter methods and the destination
+     * object has no setter methods.
+     */
+    @Test
+    public void testTransformerIsAbleToCopyObjectsWithoutRequiredMethods() {
+        //GIVEN
+        FromFooSimpleNoGetters fromFooSimpleNoGetters = new FromFooSimpleNoGetters(NAME, ID);
+        //WHEN
+        MutableToFooSimpleNoSetters actual = underTest.transform(fromFooSimpleNoGetters, MutableToFooSimpleNoSetters.class);
+
+        //THEN
+        assertThat(actual, sameBeanAs(fromFooSimpleNoGetters));
+    }
+
+    /**
+     * Test that a bean containing a field not existing in the source object, but with a transformer function defined for such object is correctly copied.
+     */
+    @Test
+    public void testThatAnyTypeOfBeanContainsANotExistingFieldInTheSourceObjectIsCorrectlyCopiedThroughTransformerFunctions() {
+        //GIVEN
+        FromFooSimple fromFooSimple = new FromFooSimple(NAME, ID);
+        FieldTransformer<Object, Integer> ageFieldTransformer = new FieldTransformer<>(AGE_FIELD_NAME, val -> AGE);
+
+        //WHEN
+        underTest.withFieldTransformer(ageFieldTransformer);
+        MutableToFooNotExistingFields mutableObjectBean = underTest.transform(fromFooSimple, MutableToFooNotExistingFields.class);
+
+        //THEN
+        assertThat(mutableObjectBean, hasProperty(AGE_FIELD_NAME, equalTo(AGE)));
+    }
+}

--- a/src/test/java/com/hotels/beans/transformer/MutableObjectTransformationTest.java
+++ b/src/test/java/com/hotels/beans/transformer/MutableObjectTransformationTest.java
@@ -36,6 +36,7 @@ import com.hotels.beans.sample.mutable.MutableToFoo;
 import com.hotels.beans.sample.mutable.MutableToFooInvalid;
 import com.hotels.beans.sample.mutable.MutableToFooNotExistingFields;
 import com.hotels.beans.sample.mutable.MutableToFooSimpleNoSetters;
+import com.hotels.beans.sample.mutable.MutableToFooSubClass;
 
 /**
  * Unit test for all {@link Transformer} functions related to Mutable type Java Beans.
@@ -151,5 +152,20 @@ public class MutableObjectTransformationTest extends AbstractTransformerTest {
 
         //THEN
         assertThat(mutableObjectBean, hasProperty(AGE_FIELD_NAME, equalTo(AGE)));
+    }
+
+    /**
+     * Test transformation on an existing bean is correctly copied.
+     */
+    @Test
+    public void testTransformationOnAnExistingDestinationWorksProperly() {
+        //GIVEN
+        MutableToFooSubClass mutableToFoo = new MutableToFooSubClass();
+
+        //WHEN
+        underTest.transform(fromFooSubClass, mutableToFoo);
+
+        //THEN
+        assertThat(mutableToFoo, sameBeanAs(fromFooSubClass));
     }
 }

--- a/src/test/java/com/hotels/beans/transformer/TransformerTest.java
+++ b/src/test/java/com/hotels/beans/transformer/TransformerTest.java
@@ -16,117 +16,30 @@
 
 package com.hotels.beans.transformer;
 
-import static java.lang.String.format;
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
-
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasProperty;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
-import static org.springframework.test.util.ReflectionTestUtils.setField;
-
-import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs;
-import static com.hotels.beans.constant.ClassType.IMMUTABLE;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.IntStream;
 
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 
-import com.hotels.beans.annotation.ConstructorArg;
-import com.hotels.beans.cache.CacheManager;
-import com.hotels.beans.error.InvalidBeanException;
-import com.hotels.beans.error.MissingFieldException;
 import com.hotels.beans.model.FieldMapping;
 import com.hotels.beans.model.FieldTransformer;
-import com.hotels.beans.sample.FromFoo;
-import com.hotels.beans.sample.FromFooAdvFields;
-import com.hotels.beans.sample.FromFooSimple;
-import com.hotels.beans.sample.FromFooSimpleNoGetters;
-import com.hotels.beans.sample.FromFooSubClass;
-import com.hotels.beans.sample.FromFooWithPrimitiveFields;
-import com.hotels.beans.sample.FromSubFoo;
-import com.hotels.beans.sample.immutable.ImmutableFlatToFoo;
-import com.hotels.beans.sample.immutable.ImmutableToFoo;
-import com.hotels.beans.sample.immutable.ImmutableToFooAdvFields;
-import com.hotels.beans.sample.immutable.ImmutableToFooCustomAnnotation;
-import com.hotels.beans.sample.immutable.ImmutableToFooDiffFields;
-import com.hotels.beans.sample.immutable.ImmutableToFooInvalid;
-import com.hotels.beans.sample.immutable.ImmutableToFooMissingCustomAnnotation;
-import com.hotels.beans.sample.immutable.ImmutableToFooNoConstructors;
-import com.hotels.beans.sample.immutable.ImmutableToFooNotExistingFields;
-import com.hotels.beans.sample.immutable.ImmutableToFooSimpleWrongTypes;
-import com.hotels.beans.sample.immutable.ImmutableToFooSubClass;
-import com.hotels.beans.sample.immutable.ImmutableToFooSimple;
-import com.hotels.beans.sample.mixed.MixedToFoo;
-import com.hotels.beans.sample.mixed.MixedToFooDiffFields;
-import com.hotels.beans.sample.mixed.MixedToFooMissingAllArgsConstructor;
-import com.hotels.beans.sample.mixed.MixedToFooMissingField;
-import com.hotels.beans.sample.mixed.MixedToFooNotExistingFields;
-import com.hotels.beans.sample.mutable.MutableToFoo;
-import com.hotels.beans.sample.mutable.MutableToFooInvalid;
-import com.hotels.beans.sample.mutable.MutableToFooNotExistingFields;
-import com.hotels.beans.sample.mutable.MutableToFooSimpleNoSetters;
-import com.hotels.beans.sample.mutable.MutableToFooSubClass;
 import com.hotels.beans.utils.ReflectionUtils;
 
 /**
- * Unit test for {@link Transformer}.
+ * Unit test for class: {@link Transformer}.
  */
-public class TransformerTest {
-    private static final BigInteger ID = new BigInteger("1234");
-    private static final String ITEM_1 = "donald";
-    private static final String ITEM_2 = "duck";
-    private static final String NAME = "Goofy";
-    private static final String SURNAME = "surname";
-    private static final int PHONE = 123;
-    private static final String INDEX_NUMBER = null;
-    private static final boolean CHECK = true;
-    private static final BigDecimal AMOUNT = new BigDecimal(10);
-    private static final String SUB_FOO_NAME = "Smith";
-    private static final int[] SUB_FOO_PHONE_NUMBERS = {12345, 6892, 10873};
-    private static final Map<String, String> SUB_FOO_SAMPLE_MAP = new HashMap<>();
-    private static final Map<String, List<String>> SUB_FOO_COMPLEX_MAP = new HashMap<>();
-    private static final Map<String, Map<String, String>> SUB_FOO_VERY_COMPLEX_MAP = new HashMap<>();
-    private static final int AGE = 34;
-    private static final int TOTAL_ADV_CLASS_FIELDS = 5;
-    private static final String AGE_FIELD_NAME = "age";
-    private static final String GET_DEST_FIELD_NAME_METHOD_NAME = "getDestFieldName";
-    private static final String GET_CONSTRUCTOR_VALUES_FROM_FIELDS_METHOD_NAME = "getConstructorValuesFromFields";
-    private static final String GET_SOURCE_FIELD_VALUE_METHOD_NAME = "getSourceFieldValue";
-    private static final String DEST_FIELD_NAME = "destFieldName";
-    private static final String REFLECTION_UTILS_FIELD_NAME = "reflectionUtils";
+public class TransformerTest extends AbstractTransformerTest {
+    private static final String SOURCE_FIELD_NAME = "sourceFieldName";
+    private static final String SOURCE_FIELD_NAME_2 = "sourceFieldName2";
     private static final String TRANSFORMER_SETTINGS_FIELD_NAME = "settings";
-    private static final String CONSTRUCTOR_PARAMETER_NAME = "constructorParameterName";
+    private static final String GET_SOURCE_FIELD_VALUE_METHOD_NAME = "getSourceFieldValue";
     private static final ReflectionUtils REFLECTION_UTILS = new ReflectionUtils();
-    private static FromFoo fromFoo;
-    private static FromFoo fromFooWithNullProperties;
-    private static FromFooSimple fromFooSimple;
-    private static FromFooWithPrimitiveFields fromFooWithPrimitiveFields;
-    private static List<FromSubFoo> fromSubFooList;
-    private static List<String> sourceFooSimpleList;
-    private static FromSubFoo fromSubFoo;
-    private static FromFooSubClass fromFooSubClass;
-    private static FromFooAdvFields fromFooAdvFields;
 
     /**
      * The class to be tested.
@@ -135,19 +48,56 @@ public class TransformerTest {
     private TransformerImpl underTest;
 
     /**
-     * Initializes the arguments and objects.
-     */
-    @BeforeClass
-    public static void beforeClass() {
-        initObjects();
-    }
-
-    /**
      * Initialized mocks.
      */
     @Before
     public void beforeMethod() {
         initMocks(this);
+    }
+
+    /**
+     * Test that is possible to remove a field mapping for a given field.
+     */
+    @Test
+    public void testRemoveFieldMappingWorksProperly() {
+        //GIVEN
+        Transformer beanTransformer = underTest.withFieldMapping(new FieldMapping(SOURCE_FIELD_NAME, DEST_FIELD_NAME));
+
+        //WHEN
+        beanTransformer.removeFieldMapping(DEST_FIELD_NAME);
+        TransformerSettings transformerSettings = (TransformerSettings) REFLECTION_UTILS.getFieldValue(beanTransformer, TRANSFORMER_SETTINGS_FIELD_NAME, TransformerSettings.class);
+
+        //THEN
+        assertFalse(transformerSettings.getFieldsNameMapping().containsKey(DEST_FIELD_NAME));
+    }
+
+    /**
+     * Test that the method {@code removeFieldMapping} raises an {@link IllegalArgumentException} if the parameter is null.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testRemoveFieldMappingRaisesExceptionIfItsCalledWithNullParam() {
+        //GIVEN
+        Transformer beanTransformer = underTest.withFieldMapping(new FieldMapping(SOURCE_FIELD_NAME, DEST_FIELD_NAME));
+
+        //WHEN
+        beanTransformer.removeFieldMapping(null);
+    }
+
+    /**
+     * Test that is possible to remove all the fields mappings defined.
+     */
+    @Test
+    public void testResetFieldsMappingWorksProperly() {
+        //GIVEN
+        Transformer beanTransformer = underTest
+                .withFieldMapping(new FieldMapping(SOURCE_FIELD_NAME, DEST_FIELD_NAME), new FieldMapping(SOURCE_FIELD_NAME_2, DEST_FIELD_NAME));
+
+        //WHEN
+        beanTransformer.resetFieldsMapping();
+        TransformerSettings transformerSettings = (TransformerSettings) REFLECTION_UTILS.getFieldValue(beanTransformer, TRANSFORMER_SETTINGS_FIELD_NAME, TransformerSettings.class);
+
+        //THEN
+        assertTrue(transformerSettings.getFieldsNameMapping().isEmpty());
     }
 
     /**
@@ -168,513 +118,31 @@ public class TransformerTest {
     }
 
     /**
-     * Test that immutable beans without constructor arguments parameter annotated with: @ConstructorArg {@link com.hotels.beans.annotation.ConstructorArg} are correctly copied.
+     * Test that is possible to remove a field transformer for a given field.
      */
     @Test
-    public void testBeanWithoutCustomAnnotationIsCorrectlyCopied() {
+    public void testRemoveFieldTransformerWorksProperly() {
         //GIVEN
+        Transformer beanTransformer = underTest.withFieldTransformer(new FieldTransformer<>(DEST_FIELD_NAME, val -> val));
 
         //WHEN
-        ImmutableToFoo actual = underTest.transform(fromFoo, ImmutableToFoo.class);
+        beanTransformer.removeFieldTransformer(DEST_FIELD_NAME);
+        TransformerSettings transformerSettings = (TransformerSettings) REFLECTION_UTILS.getFieldValue(beanTransformer, TRANSFORMER_SETTINGS_FIELD_NAME, TransformerSettings.class);
 
         //THEN
-        assertThat(actual, sameBeanAs(fromFoo));
+        assertFalse(transformerSettings.getFieldsTransformers().containsKey(DEST_FIELD_NAME));
     }
 
     /**
-     * Test that, in case a destination object field is contained into a nested object of the source field, defining a composite {@link FieldMapping} the field is correctly
-     * valorized.
+     * Test that the method {@code removeFieldTransformer} raises an {@link IllegalArgumentException} if the parameter is null.
      */
-    @Test
-    public void testTransformationWithCompositeFieldNameMappingIsWorkingAsExpected() {
+    @Test(expected = IllegalArgumentException.class)
+    public void testRemoveFieldTransformerRaisesExceptionIfItsCalledWithNullParam() {
         //GIVEN
-        FieldMapping phoneNumbersMapping = new FieldMapping("nestedObject.phoneNumbers", "phoneNumbers");
+        Transformer beanTransformer = underTest.withFieldTransformer(new FieldTransformer<>(DEST_FIELD_NAME, val -> val));
 
         //WHEN
-        ImmutableFlatToFoo actual = underTest.withFieldMapping(phoneNumbersMapping).transform(fromFoo, ImmutableFlatToFoo.class);
-
-        //THEN
-        assertEquals(fromFoo.getName(), actual.getName());
-        assertEquals(fromFoo.getId(), actual.getId());
-        assertEquals(fromFoo.getNestedObject().getPhoneNumbers(), actual.getPhoneNumbers());
-        underTest.resetFieldsMapping();
-    }
-
-    /**
-     * Test that, in case a destination object field is contained into a nested object of the source field, defining a composite {@link FieldMapping} the field is correctly
-     * valorized even if some of them are null.
-     */
-    @Test
-    public void testTransformationWithCompositeFieldNameWorksEvenWithNullObjects() {
-        //GIVEN
-        FieldMapping phoneNumbersMapping = new FieldMapping("nestedObject.phoneNumbers", "phoneNumbers");
-
-        //WHEN
-        ImmutableFlatToFoo actual = underTest.withFieldMapping(phoneNumbersMapping).transform(fromFooWithNullProperties, ImmutableFlatToFoo.class);
-
-        //THEN
-        assertEquals(fromFooWithNullProperties.getName(), actual.getName());
-        assertEquals(fromFooWithNullProperties.getId(), actual.getId());
-        assertNull(actual.getPhoneNumbers());
-        underTest.resetFieldsMapping();
-    }
-
-    /**
-     * Test that immutable beans without custom field mapping.
-     */
-    @Test
-    public void testBeanWithEmptyFieldMappingIsCorrectlyCopied() {
-        //GIVEN
-
-        //WHEN
-        ImmutableToFoo actual = underTest.withFieldMapping().transform(fromFoo, ImmutableToFoo.class);
-
-        //THEN
-        assertThat(actual, sameBeanAs(fromFoo));
-    }
-
-    /**
-     * Test that immutable beans without custom field mapping.
-     */
-    @Test
-    public void testBeanWithEmptyFieldTransformerIsCorrectlyCopied() {
-        //GIVEN
-
-        //WHEN
-        ImmutableToFoo actual = underTest.withFieldMapping().transform(fromFoo, ImmutableToFoo.class);
-
-        //THEN
-        assertThat(actual, sameBeanAs(fromFoo));
-    }
-
-    /**
-     * Test that immutable beans with constructor arguments parameter annotated with: @ConstructorArg {@link com.hotels.beans.annotation.ConstructorArg} are correctly copied.
-     */
-    @Test
-    public void testBeanWithCustomAnnotationIsCorrectlyCopied() {
-        //GIVEN
-
-        //WHEN
-        ImmutableToFooCustomAnnotation actual = underTest.transform(fromFoo, ImmutableToFooCustomAnnotation.class);
-
-        //THEN
-        assertThat(actual, sameBeanAs(fromFoo));
-    }
-
-    /**
-     * Test that an exception is thrown if the constructor invocation throws exception.
-     */
-    @Test(expected = InvalidBeanException.class)
-    public void testTransformThrowsExceptionIfTheConstructorInvocationThrowsException() {
-        //GIVEN
-        FromFoo actual = new FromFoo(NAME, ID, null, null, null);
-
-        //WHEN
-        underTest.transform(actual, ImmutableToFooCustomAnnotation.class);
-    }
-
-    /**
-     * Test that an exception is thrown if no constructors are defined.
-     */
-    @Test(expected = InvalidBeanException.class)
-    public void testTransformThrowsExceptionWhenParameterAreNull() {
-        //GIVEN
-        FromFoo actual = new FromFoo(NAME, ID, null, null, null);
-
-        //WHEN
-        underTest.transform(actual, ImmutableToFooNoConstructors.class);
-    }
-
-    /**
-     * Test that an exception is thrown if there is no default constructor defined for the mutable bean object.
-     */
-    @Test(expected = InvalidBeanException.class)
-    public void testTransformThrowsExceptionWhenMutableBeanHasNoDefaultConstructor() {
-        //GIVEN
-
-        //WHEN
-        underTest.transform(fromFoo, MutableToFooInvalid.class);
-    }
-
-    /**
-     * Test that an exception is thrown if there the constructor args parameters have a different order for the mutable bean object.
-     */
-    @Test(expected = InvalidBeanException.class)
-    public void testTransformThrowsExceptionWhenImmutableBeanHasAWrongConstructor() {
-        //GIVEN
-
-        //WHEN
-        underTest.transform(fromFoo, ImmutableToFooInvalid.class);
-    }
-
-    /**
-     * Test that an exception is thrown if the destination object don't met the constraints.
-     */
-    @Test(expected = InvalidBeanException.class)
-    public void testTransformThrowsExceptionIfTheDestinationObjectValuesAreNotValid() {
-        //GIVEN
-        fromFoo.setName(null);
-
-        //WHEN
-        underTest.transform(fromFoo, ImmutableToFoo.class);
-
-        // THEN
-        fromFoo.setName(NAME);
-    }
-
-    /**
-     * Test that no exception is thrown if the destination object don't met the constraints and the validation is disabled.
-     */
-    @Test
-    public void testTransformThrowsNoExceptionIfTheDestinationObjectValuesAreNotValidAndTheValidationIsDisabled() {
-        //GIVEN
-        fromFoo.setName(null);
-        underTest.setValidationDisabled(true);
-
-        //WHEN
-        ImmutableToFoo actual = underTest.transform(fromFoo, ImmutableToFoo.class);
-
-        // THEN
-        assertThat(actual, sameBeanAs(fromFoo));
-        fromFoo.setName(NAME);
-        underTest.setValidationDisabled(false);
-    }
-
-    /**
-     * Test that a Mixed bean with a constructor containing the final field only is correctly copied.
-     */
-    @Test
-    public void testMixedBeanWithoutAllArgsConstructorIsCorrectlyCopied() {
-        //GIVEN
-
-        //WHEN
-        MixedToFooMissingAllArgsConstructor actual = underTest.transform(fromFoo, MixedToFooMissingAllArgsConstructor.class);
-
-        //THEN
-        assertThat(actual, sameBeanAs(fromFoo));
-    }
-
-    /**
-     * Test mutable beans are correctly copied.
-     */
-    @Test
-    public void testMutableBeanIsCorrectlyCopied() {
-        //GIVEN
-
-        //WHEN
-        MutableToFoo actual = underTest.transform(fromFoo, MutableToFoo.class);
-
-        //THEN
-        assertThat(actual, sameBeanAs(fromFoo));
-    }
-
-    /**
-     * Test that a given field transformer function is applied only to a specific field even if there are other ones with same name.
-     */
-    @Test
-    public void testFieldTransformationIsAppliedOnlyToASpecificField() {
-        //GIVEN
-        String namePrefix = "prefix-";
-        FieldTransformer<String, String> nameTransformer = new FieldTransformer<>("nestedObject.name", val -> namePrefix + val);
-
-        //WHEN
-        MutableToFoo actual = underTest
-                .withFieldTransformer(nameTransformer)
-                .transform(fromFoo, MutableToFoo.class);
-
-        //THEN
-        assertEquals(fromFoo.getName(), actual.getName());
-        assertEquals(namePrefix + fromFoo.getNestedObject().getName(), actual.getNestedObject().getName());
-        underTest.resetFieldsTransformer();
-    }
-
-    /**
-     * Test that a given field transformer function is applied to all field matching the given name when {@code flatFieldNameTransformation} is set to true.
-     */
-    @Test
-    public void testFieldTransformationIsAppliedToAllMatchingFields() {
-        //GIVEN
-        String namePrefix = "prefix-";
-        FieldTransformer<String, String> nameTransformer = new FieldTransformer<>("name", val -> namePrefix + val);
-
-        //WHEN
-        MutableToFoo actual = underTest
-                .setFlatFieldNameTransformation(true)
-                .withFieldTransformer(nameTransformer)
-                .transform(fromFoo, MutableToFoo.class);
-
-        //THEN
-        assertEquals(namePrefix + fromFoo.getName(), actual.getName());
-        assertEquals(namePrefix + fromFoo.getNestedObject().getName(), actual.getNestedObject().getName());
-        underTest.resetFieldsTransformer();
-    }
-
-    /**
-     * Test that bean that extends another class are correctly copied.
-     */
-    @Test
-    public void testBeanWithoutCustomAnnotationAndWithSuperclassIsCorrectlyCopied() {
-        //GIVEN
-
-        //WHEN
-        ImmutableToFooSubClass actual = underTest.transform(fromFooSubClass, ImmutableToFooSubClass.class);
-
-        //THEN
-        assertThat(actual, sameBeanAs(fromFooSubClass));
-    }
-
-    /**
-     * Test that bean containing both final fields and not are correctly copied.
-     */
-    @Test
-    public void testMixedBeanIsCorrectlyCopied() {
-        //GIVEN
-
-        //WHEN
-        MixedToFoo actual = underTest.transform(fromFoo, MixedToFoo.class);
-
-        //THEN
-        assertThat(actual, sameBeanAs(fromFoo));
-    }
-
-    /**
-     * Test that bean containing both final fields (with different names) and not are correctly copied.
-     */
-    @Test
-    public void testMixedBeanWithDifferentFieldNamesIsCorrectlyCopied() {
-        //GIVEN
-
-        //WHEN
-        final Transformer beanTransformer = underTest.withFieldMapping(new FieldMapping("id", "identifier"));
-        MixedToFooDiffFields actual = beanTransformer.transform(fromFoo, MixedToFooDiffFields.class);
-
-        //THEN
-        assertThat(actual, hasProperty("name", equalTo(actual.getName())));
-        assertThat(actual, hasProperty("identifier", equalTo(fromFoo.getId())));
-        assertEquals(actual.getList(), fromFoo.getList());
-        IntStream.range(0, actual.getNestedObjectList().size())
-                .forEach(i -> assertThat(actual.getNestedObjectList().get(i), sameBeanAs(fromFoo.getNestedObjectList().get(i))));
-        assertThat(actual.getNestedObject(), sameBeanAs(fromFoo.getNestedObject()));
-    }
-
-    /**
-     * Test that bean containing both final fields (with different names) and not are correctly copied through field transformer.
-     */
-    @Test
-    public void testMixedBeanWithDifferentFieldNamesIsCorrectlyCopiedThroughFieldTransformer() {
-        //GIVEN
-        /* Extended declaration.
-         * Function<BigInteger, BigInteger> idTransformer = value -> value.negate();
-         * FieldTransformer<BigInteger, BigInteger> fieldTransformer = new FieldTransformer<>("identifier", idTransformer);
-         */
-        FieldTransformer<BigInteger, BigInteger> fieldTransformer = new FieldTransformer<>("identifier", BigInteger::negate);
-
-        //WHEN
-        underTest.withFieldMapping(new FieldMapping("id", "identifier")).withFieldTransformer(fieldTransformer);
-        MixedToFooDiffFields actual = underTest.transform(fromFoo, MixedToFooDiffFields.class);
-
-        //THEN
-        assertThat(actual, hasProperty("name", equalTo(actual.getName())));
-        assertThat(actual, hasProperty("identifier", equalTo(fromFoo.getId().negate())));
-        assertEquals(actual.getList(), fromFoo.getList());
-        IntStream.range(0, actual.getNestedObjectList().size())
-                .forEach(i -> assertThat(actual.getNestedObjectList().get(i), sameBeanAs(fromFoo.getNestedObjectList().get(i))));
-        assertThat(actual.getNestedObject(), sameBeanAs(fromFoo.getNestedObject()));
-    }
-
-    /**
-     * Test that a bean containing a field not existing in the source object, but with a transformer function defined for such object is correctly copied.
-     */
-    @Test
-    public void testThatAnyTypeOfBeanContainsANotExistingFieldInTheSourceObjectIsCorrectlyCopiedThroughTransformerFunctions() {
-        //GIVEN
-        FromFooSimple fromFooSimple = new FromFooSimple(NAME, ID);
-        FieldTransformer<Object, Integer> ageFieldTransformer = new FieldTransformer<>(AGE_FIELD_NAME, val -> AGE);
-
-        //WHEN
-        underTest.withFieldTransformer(ageFieldTransformer);
-        MixedToFooNotExistingFields mixedObjectBean = underTest.transform(fromFooSimple, MixedToFooNotExistingFields.class);
-        ImmutableToFooNotExistingFields immutableObjectBean = underTest.transform(fromFooSimple, ImmutableToFooNotExistingFields.class);
-        MutableToFooNotExistingFields mutableObjectBean = underTest.transform(fromFooSimple, MutableToFooNotExistingFields.class);
-
-        //THEN
-        assertThat(mixedObjectBean, hasProperty(AGE_FIELD_NAME, equalTo(AGE)));
-        assertThat(immutableObjectBean, hasProperty(AGE_FIELD_NAME, equalTo(AGE)));
-        assertThat(mutableObjectBean, hasProperty(AGE_FIELD_NAME, equalTo(AGE)));
-    }
-
-    /**
-     * Test that the copy method sets the default value when the source object does not contain a required field.
-     */
-    @Test
-    public void testMixedBeanWithMissingFieldsReturnsTheDefaultValueWhenTheSourceObjectDoesNotContainARequiredField() {
-        //GIVEN
-        underTest.setDefaultValueForMissingField(true);
-
-        //WHEN
-        MixedToFooMissingField actual = underTest.transform(fromFoo, MixedToFooMissingField.class);
-
-        assertNull(actual.getFooField());
-        underTest.setDefaultValueForMissingField(false);
-    }
-
-    /**
-     * Test that the copy method raises an exception when the source object does not contain a required field.
-     */
-    @Test(expected = MissingFieldException.class)
-    public void testMixedBeanWithMissingFieldsThrowsMissingFieldExceptionWhenTheSourceObjectDoesNotContainARequiredField() {
-        //GIVEN
-        underTest.setDefaultValueForMissingField(false);
-
-        //WHEN
-        underTest.transform(fromFoo, MixedToFooMissingField.class);
-    }
-
-    /**
-     * Test that bean containing final fields (with different field names) are correctly copied.
-     */
-    @Test
-    public void testImmutableBeanWithDifferentFieldNamesIsCorrectlyCopied() {
-        //GIVEN
-
-        //WHEN
-        final Transformer beanTransformer = underTest.withFieldMapping(new FieldMapping("id", "identifier"));
-        ImmutableToFooDiffFields actual = beanTransformer.transform(fromFoo, ImmutableToFooDiffFields.class);
-
-        //THEN
-        assertThat(actual, hasProperty("name", equalTo(actual.getName())));
-        assertThat(actual, hasProperty("identifier", equalTo(fromFoo.getId())));
-        assertEquals(actual.getList(), fromFoo.getList());
-        IntStream.range(0, actual.getNestedObjectList().size())
-                .forEach(i -> assertThat(actual.getNestedObjectList().get(i), sameBeanAs(fromFoo.getNestedObjectList().get(i))));
-        assertThat(actual.getNestedObject(), sameBeanAs(fromFoo.getNestedObject()));
-    }
-
-    /**
-     * Test that bean containing advanced final fields are correctly copied.
-     */
-    @Test
-    public void testImmutableBeanWithAdvancedFieldsIsCorrectlyCopied() {
-        //GIVEN
-
-        //WHEN
-        final Transformer beanTransformer = underTest
-                .withFieldMapping(new FieldMapping("id", "identifier"))
-                .withFieldTransformer(new FieldTransformer<>("locale", Locale::forLanguageTag));
-        ImmutableToFooAdvFields actual = beanTransformer.transform(fromFooAdvFields, ImmutableToFooAdvFields.class);
-
-        //THEN
-        assertNotNull(actual.getName());
-        assertTrue(actual.getName().isPresent());
-        assertEquals(fromFooAdvFields.getName().get(), actual.getName().get());
-        assertEquals(fromFooAdvFields.getAge().get(), actual.getAge());
-        assertEquals(fromFooAdvFields.getClassType(), actual.getClassType());
-        assertEquals(fromFooAdvFields.getLocale(), actual.getLocale().getLanguage());
-    }
-
-    /**
-     * Test that immutable bean containing a constructor with some field not annotated with
-     * {@link com.hotels.beans.annotation.ConstructorArg} is correctly copied.
-     */
-    @Test
-    public void testImmutableBeanWithMissingConstructorArgIsCorrectlyCopied() {
-        //GIVEN
-
-        //WHEN
-        ImmutableToFooMissingCustomAnnotation actual = underTest.withFieldTransformer().transform(fromFooWithPrimitiveFields, ImmutableToFooMissingCustomAnnotation.class);
-
-        //THEN
-        assertNotNull(actual);
-        assertEquals(fromFooWithPrimitiveFields.getName(), actual.getName());
-    }
-
-    /**
-     * Test that method: {@code getDestFieldName} retrieves the param name from the {@link ConstructorArg} if it is not provided from jvm directly.
-     */
-    @Test
-    public void testGetDestFieldNameIsRetrievedFromConstructorArgIfTheParamNameIsNotProvidedFromJVM() throws Exception {
-        //GIVEN
-        String declaringClassName = ImmutableToFoo.class.getName();
-        // Parameter mock setup
-        Parameter constructorParameter = mock(Parameter.class);
-        when(constructorParameter.getName()).thenReturn(CONSTRUCTOR_PARAMETER_NAME);
-
-        // CacheManager mock setup
-        initGetDestFieldNameTestMock(declaringClassName, constructorParameter);
-        Method getDestFieldNameMethod = underTest.getClass().getDeclaredMethod(GET_DEST_FIELD_NAME_METHOD_NAME, Parameter.class, String.class);
-        getDestFieldNameMethod.setAccessible(true);
-
-        //WHEN
-        String actual = (String) getDestFieldNameMethod.invoke(underTest, constructorParameter, declaringClassName);
-
-        //THEN
-        assertEquals(DEST_FIELD_NAME, actual);
-
-        // restore modified objects
-        restoreObjects(getDestFieldNameMethod);
-    }
-
-    /**
-     * Test that the method: {@code getConstructorValuesFromFields} works properly.
-     */
-    @Test
-    public void testGetConstructorValuesFromFieldsWorksProperly() throws Exception {
-        //GIVEN
-        underTest.withFieldTransformer(new FieldTransformer<>("locale", Locale::forLanguageTag));
-
-        //WHEN
-        final Method getConstructorValuesFromFieldsMethod =
-                underTest.getClass().getDeclaredMethod(GET_CONSTRUCTOR_VALUES_FROM_FIELDS_METHOD_NAME, Object.class, Class.class, String.class);
-        getConstructorValuesFromFieldsMethod.setAccessible(true);
-        Object[] actual = (Object[]) getConstructorValuesFromFieldsMethod.invoke(underTest, fromFooAdvFields, ImmutableToFooAdvFields.class, "");
-
-        //THEN
-        assertNotNull(actual);
-        assertEquals(TOTAL_ADV_CLASS_FIELDS, actual.length);
-
-        // restore modified objects
-        restoreObjects(getConstructorValuesFromFieldsMethod);
-    }
-
-    /**
-     * Test that method: {@code getDestFieldName} returns null if the constructor's parameter name is not provided from jvm directly and the {@link ConstructorArg} is not defined.
-     */
-    @Test
-    public void testGetDestFieldNameReturnsNullIfConstructorParamHasNoNameProvidedFromJVMAndNoConstructorArgIsDefined() throws Exception {
-        //GIVEN
-        String declaringClassName = ImmutableToFoo.class.getName();
-        // Parameter mock setup
-        Parameter constructorParameter = mock(Parameter.class);
-        when(constructorParameter.getName()).thenReturn(null);
-
-        // CacheManager mock setup
-        initGetDestFieldNameTestMock(declaringClassName, constructorParameter);
-        Method getDestFieldNameMethod = underTest.getClass().getDeclaredMethod(GET_DEST_FIELD_NAME_METHOD_NAME, Parameter.class, String.class);
-        getDestFieldNameMethod.setAccessible(true);
-
-        //WHEN
-        String actual = (String) getDestFieldNameMethod.invoke(underTest, constructorParameter, declaringClassName);
-
-        //THEN
-        assertEquals(DEST_FIELD_NAME, actual);
-
-        // restore modified objects
-        restoreObjects(getDestFieldNameMethod);
-    }
-
-    /**
-     * Test that the transformer is able to copy object even if the source object has no setter methods and the destination
-     * object has no setter methods.
-     */
-    @Test
-    public void testTransformerIsAbleToCopyObjectsWithoutRequiredMethods() {
-        //GIVEN
-        FromFooSimpleNoGetters fromFooSimpleNoGetters = new FromFooSimpleNoGetters(NAME, ID);
-        //WHEN
-        MutableToFooSimpleNoSetters actual = underTest.transform(fromFooSimpleNoGetters, MutableToFooSimpleNoSetters.class);
-
-        //THEN
-        assertThat(actual, sameBeanAs(fromFooSimpleNoGetters));
+        beanTransformer.removeFieldTransformer(null);
     }
 
     /**
@@ -690,135 +158,4 @@ public class TransformerTest {
         getSourceFieldValueMethod.invoke(underTest, null, null, null, false);
     }
 
-    /**
-     * Test that a meaningful exception is returned when a constructor is invoked with wrong arguments.
-     */
-    @Test
-    public void testTransformationReturnsAMeaningfulException() {
-        //GIVEN
-        Class<ImmutableToFooSimpleWrongTypes> targetClass = ImmutableToFooSimpleWrongTypes.class;
-        final String expectedExceptionMessageFormat =
-                "Constructor invoked with arguments. Expected: public %s(java.lang.Integer,java.lang.String); Found: %s(java.math.BigInteger,java.lang.String). "
-                +  "Double check that each %s's field have the same type and name than the source object: %s otherwise specify a transformer configuration.";
-        String targetClassName = targetClass.getCanonicalName();
-        String expectedExceptionMessage =
-                format(expectedExceptionMessageFormat, targetClassName, targetClassName, targetClass.getSimpleName(), fromFooSimple.getClass().getCanonicalName());
-
-        //WHEN
-        Exception raisedException = null;
-        try {
-            underTest.transform(fromFooSimple, targetClass);
-        } catch (final Exception e) {
-            raisedException = e;
-        }
-
-        //THEN
-        assertNotNull(raisedException);
-        assertEquals(InvalidBeanException.class, raisedException.getClass());
-        assertEquals(expectedExceptionMessage, raisedException.getMessage());
-    }
-
-    /**
-     * Test transformation on an existing bean is correctly copied.
-     */
-    @Test
-    public void testTransformationOnAnExistingDestinationWorksProperly() {
-        //GIVEN
-        MutableToFooSubClass mutableToFoo = new MutableToFooSubClass();
-        ImmutableToFooSimple immutableToFoo = new ImmutableToFooSimple(null, null);
-
-        //WHEN
-        underTest.transform(fromFooSubClass, mutableToFoo);
-        underTest.transform(fromFooSimple, immutableToFoo);
-
-        //THEN
-        assertThat(mutableToFoo, sameBeanAs(fromFooSubClass));
-        assertThat(immutableToFoo, sameBeanAs(fromFooSimple));
-    }
-
-    /**
-     * Initializes the mocks required for testing method: {@code getDestFieldName}.
-     * @param declaringClassName the declaring class name
-     * @param constructorParameter the constructor parameter
-     */
-    private void initGetDestFieldNameTestMock(final String declaringClassName, final Parameter constructorParameter) {
-        CacheManager cacheManager = mock(CacheManager.class);
-        String cacheKey = "DestFieldName-" + declaringClassName + "-" + CONSTRUCTOR_PARAMETER_NAME;
-        when(cacheManager.getFromCache(cacheKey, String.class)).thenReturn(null);
-        // ConstructorArg mock setup
-        ConstructorArg constructorArg = mock(ConstructorArg.class);
-        when(constructorArg.value()).thenReturn(DEST_FIELD_NAME);
-        // ReflectionUtils mock setup
-        ReflectionUtils reflectionUtils = mock(ReflectionUtils.class);
-        when(reflectionUtils.getParameterAnnotation(constructorParameter, ConstructorArg.class, declaringClassName)).thenReturn(constructorArg);
-        setField(underTest, REFLECTION_UTILS_FIELD_NAME, reflectionUtils);
-    }
-
-    /**
-     * Restored the initial object status before testing method: {@code getDestFieldName}.
-     */
-    private void restoreObjects(final Method getDestFieldNameMethod) {
-        getDestFieldNameMethod.setAccessible(false);
-        setField(underTest, REFLECTION_UTILS_FIELD_NAME, new ReflectionUtils());
-    }
-
-    /**
-     * Create an instance of two objects: one without custom annotation and another one with custom annotations then execute the copy into a specular immutable object.
-     */
-    private static void initObjects() {
-        SUB_FOO_SAMPLE_MAP.put(ITEM_1, ITEM_2);
-        SUB_FOO_COMPLEX_MAP.put(ITEM_1, singletonList(ITEM_2));
-        SUB_FOO_VERY_COMPLEX_MAP.put(ITEM_1, SUB_FOO_SAMPLE_MAP);
-        fromSubFoo = new FromSubFoo(SUB_FOO_NAME, SUB_FOO_PHONE_NUMBERS, SUB_FOO_SAMPLE_MAP, SUB_FOO_COMPLEX_MAP, SUB_FOO_VERY_COMPLEX_MAP);
-        fromSubFooList = singletonList(fromSubFoo);
-        sourceFooSimpleList = asList(ITEM_1, ITEM_2);
-        fromFoo = createFromFoo(fromSubFoo);
-        fromFooWithNullProperties = createFromFoo(null);
-        fromFooSimple = createFromFooSimple();
-        fromFooWithPrimitiveFields = createFromFooWithPrimitiveFields();
-        fromFooSubClass = createFromFooSubClass();
-        fromFooAdvFields = createFromFooAdvFields();
-    }
-
-    /**
-     * Creates a {@link FromFoo} instance.
-     * @param fromSubFoo the {@link FromSubFoo} instance
-     * @return the {@link FromFoo} instance.
-     */
-    private static FromFoo createFromFoo(final FromSubFoo fromSubFoo) {
-        return new FromFoo(NAME, ID, fromSubFooList, sourceFooSimpleList, fromSubFoo);
-    }
-
-    /**
-     * Creates a {@link FromFooSimple} instance.
-     * @return the {@link FromFooSimple} instance.
-     */
-    private static FromFooSimple createFromFooSimple() {
-        return new FromFooSimple(NAME, ID);
-    }
-
-
-    /**
-     * Creates a {@link FromFooWithPrimitiveFields} instance.
-     * @return the {@link FromFooWithPrimitiveFields} instance.
-     */
-    private static FromFooWithPrimitiveFields createFromFooWithPrimitiveFields() {
-        return new FromFooWithPrimitiveFields(NAME, ID.intValue(), AGE, fromSubFooList, sourceFooSimpleList, fromSubFoo);
-    }
-
-    /**
-     * Creates a {@link FromFooSubClass} instance.
-     * @return the {@link FromFooSubClass} instance.
-     */
-    private static FromFooSubClass createFromFooSubClass() {
-        return new FromFooSubClass(fromFoo.getName(), fromFoo.getId(), fromFoo.getNestedObjectList(), fromFoo.getList(), fromFoo.getNestedObject(), SURNAME, PHONE, CHECK, AMOUNT);
-    }
-
-    /**
-     * Creates a {@link FromFooAdvFields} instance.
-     * @return the {@link FromFooAdvFields} instance.
-     */
-    private static FromFooAdvFields createFromFooAdvFields() {
-        return new FromFooAdvFields(Optional.of(NAME), Optional.of(AGE), INDEX_NUMBER, IMMUTABLE, Locale.ENGLISH.getLanguage());
-    }
 }

--- a/src/test/java/com/hotels/beans/transformer/TransformerTest.java
+++ b/src/test/java/com/hotels/beans/transformer/TransformerTest.java
@@ -115,7 +115,7 @@ public class TransformerTest {
     private static final String GET_SOURCE_FIELD_VALUE_METHOD_NAME = "getSourceFieldValue";
     private static final String DEST_FIELD_NAME = "destFieldName";
     private static final String REFLECTION_UTILS_FIELD_NAME = "reflectionUtils";
-    private static final String TRANSFORMER_SETTINGS_FIELD_NAME = "transformerSettings";
+    private static final String TRANSFORMER_SETTINGS_FIELD_NAME = "settings";
     private static final String CONSTRUCTOR_PARAMETER_NAME = "constructorParameterName";
     private static final ReflectionUtils REFLECTION_UTILS = new ReflectionUtils();
     private static FromFoo fromFoo;

--- a/src/test/java/com/hotels/beans/transformer/TransformerTest.java
+++ b/src/test/java/com/hotels/beans/transformer/TransformerTest.java
@@ -76,6 +76,7 @@ import com.hotels.beans.sample.immutable.ImmutableToFooNoConstructors;
 import com.hotels.beans.sample.immutable.ImmutableToFooNotExistingFields;
 import com.hotels.beans.sample.immutable.ImmutableToFooSimpleWrongTypes;
 import com.hotels.beans.sample.immutable.ImmutableToFooSubClass;
+import com.hotels.beans.sample.immutable.ImmutableToFooSimple;
 import com.hotels.beans.sample.mixed.MixedToFoo;
 import com.hotels.beans.sample.mixed.MixedToFooDiffFields;
 import com.hotels.beans.sample.mixed.MixedToFooMissingAllArgsConstructor;
@@ -85,6 +86,7 @@ import com.hotels.beans.sample.mutable.MutableToFoo;
 import com.hotels.beans.sample.mutable.MutableToFooInvalid;
 import com.hotels.beans.sample.mutable.MutableToFooNotExistingFields;
 import com.hotels.beans.sample.mutable.MutableToFooSimpleNoSetters;
+import com.hotels.beans.sample.mutable.MutableToFooSubClass;
 import com.hotels.beans.utils.ReflectionUtils;
 
 /**
@@ -147,7 +149,6 @@ public class TransformerTest {
     public void beforeMethod() {
         initMocks(this);
     }
-
 
     /**
      * Test that is possible to remove all the fields transformer defined.
@@ -715,6 +716,24 @@ public class TransformerTest {
         assertNotNull(raisedException);
         assertEquals(InvalidBeanException.class, raisedException.getClass());
         assertEquals(expectedExceptionMessage, raisedException.getMessage());
+    }
+
+    /**
+     * Test transformation on an existing bean is correctly copied.
+     */
+    @Test
+    public void testTransformationOnAnExistingDestinationWorksProperly() {
+        //GIVEN
+        MutableToFooSubClass mutableToFoo = new MutableToFooSubClass();
+        ImmutableToFooSimple immutableToFoo = new ImmutableToFooSimple(null, null);
+
+        //WHEN
+        underTest.transform(fromFooSubClass, mutableToFoo);
+        underTest.transform(fromFooSimple, immutableToFoo);
+
+        //THEN
+        assertThat(mutableToFoo, sameBeanAs(fromFooSubClass));
+        assertThat(immutableToFoo, sameBeanAs(fromFooSimple));
     }
 
     /**

--- a/src/test/java/com/hotels/beans/utils/ReflectionUtilsTest.java
+++ b/src/test/java/com/hotels/beans/utils/ReflectionUtilsTest.java
@@ -58,7 +58,6 @@ public class ReflectionUtilsTest {
     private static final String LIST_FIELD_NAME = "list";
     private static final String GETTER_METHOD_PREFIX_METHOD_NAME = "getGetterMethodPrefix";
     private static final String CHECK_FIELD_NAME = "check";
-    private static final String NAME_FIELD = "name";
     private static final String EXPECTED_SETTER_METHOD_NAME = "setId";
 
     /**
@@ -198,7 +197,7 @@ public class ReflectionUtilsTest {
     @Test
     public void testGetFieldAnnotationWorksProperly() throws NoSuchFieldException {
         // GIVEN
-        Field nameField = ImmutableToFoo.class.getDeclaredField(NAME_FIELD);
+        Field nameField = ImmutableToFoo.class.getDeclaredField(ID_FIELD_NAME);
 
         // WHEN
         final NotNull notNullFieldAnnotation = underTest.getFieldAnnotation(nameField, NotNull.class);


### PR DESCRIPTION
## Description

Implemented a new feature that allows the copy on an existing object instance.

Fixes # 24

## How Has This Been Tested?

Tested that the transformation works well on existing instances too. The test has been performed on

- [X] Mutable Java Beans
- [X] Immutable Java Beans
- [X] Mixed Java Beans

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] My changes have no bad impacts on performances
