### PR TITLE
Feature/issue 38 skip field transformation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 cache:
   directories:
   - "~/.m2/repository"
-jdk: oraclejdk11
+jdk: openjdk11
 env:
   global:
   # Sonatype jira info

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 cache:
   directories:
   - "~/.m2/repository"
-jdk: openjdk11
+jdk: oraclejdk11
 env:
   global:
   # Sonatype jira info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+### [1.2.3] 2019.03.22
+#### Added
+* Implemented a new feature that allows to skip the transformation for a given set of fields (see: [Issue 38](https://github.com/HotelsDotCom/bull/issues/38))
+* Performance improvement
+
 ### [1.2.2] 2019.03.20
 #### Changed
 * Replaced `junit` test with `testng`
@@ -19,6 +24,11 @@ All notable changes to this project will be documented in this file.
 - Updated `jdk` version to 11 (was 1.8).
 - Updated Travis configuration in order to work with java 11
 - Modified Travis configuration in order to automatically create the GitHub site as soon as a tag is created
+
+### [1.1.8] 2019.03.22
+#### Added
+* Implemented a new feature that allows to skip the transformation for a given set of fields (see: [Issue 38](https://github.com/HotelsDotCom/bull/issues/38))
+* Performance improvement
 
 ### [1.1.7] 2019.03.20
 #### Changed

--- a/README.md
+++ b/README.md
@@ -51,12 +51,13 @@ mvn clean install -P relaxed
 * support copy with array containing primitive types. e.g. `String[]` => `String[]`
 * support copy with array type. e.g. `BeanA[]` => `BeanB[]`
 * support copy with property name mapping. e.g. `int id => int userId`
-* support copy with recursion copy
-* support validation through annotations
-* support copy of beans with different field's name
-* support lambda function field transformation
+* support copy with recursion copy.
+* support validation through annotations.
+* support copy of beans with different field's name.
+* support lambda function field transformation.
 * easy usage, declarative way to define the property mapping (in case of different names) or simply adding the lombok annotations.
 * allows to set the default value for all objects not existing in the source object.
+* allows to skip transformation for a given set of fields.
 
 # Transformation samples
 
@@ -374,6 +375,59 @@ if you need to perform the copy on an already existing object, just do:
 ~~~Java
 ToBean toBean = new ToBean();
 beanUtils.getTransformer().transform(fromBean, toBean);
+~~~
+
+### Skip transformation on a given set of fields:
+
+Given:
+
+~~~Java
+public class FromBean {                                     public class ToBean {                           
+   private final String name;                                  private String name;                   
+   private final FromSubBean nestedObject;                     private ToSubBean nestedObject;                    
+
+   // all args constructor                                     // constructor
+   // getters...                                               // getters and setters...
+}                                                           }
+
+public class FromBean2 {                   
+   private final int index;             
+   private final FromSubBean nestedObject;
+                                          
+   // all args constructor                
+   // getters...                          
+}                                         
+~~~
+if you need to skip the transformation for a given field, just do:
+~~~Java
+ToBean toBean = new ToBean();
+beanUtils.getTransformer()
+    .skipTransformationForField("nestedObject")
+    .transform(fromBean, toBean);
+~~~
+
+where `nestedObject` is the name of the field in the destination object.
+
+This feature allows to **transform an object keeping the data from different sources**.
+
+To better explain this function let's assume that the `ToBean` (defined above) should be transformed as follow:
+- `name` field value has be taken from the `FromBean` object
+- `nestedObject` field value has be taken from the `FromBean2` object
+
+the objective can be reached by doing:
+~~~Java
+// create the destination object
+ToBean toBean = new ToBean();
+
+// execute the first transformation skipping the copy of: 'nestedObject' field that should come from the other source object
+beanUtils.getTransformer()
+    .skipTransformationForField("nestedObject")
+    .transform(fromBean, toBean);
+
+// then execute the transformation skipping the copy of: 'name' field that should come from the other source object
+beanUtils.getTransformer()
+    .skipTransformationForField("name")
+    .transform(fromBean2, toBean);
 ~~~
 
 More sample beans can be found in the test package: `com.hotels.beans.sample`

--- a/docs/site/markdown/index.md
+++ b/docs/site/markdown/index.md
@@ -24,9 +24,11 @@ This BeanUtils library is a utility library for managing Bean objects. The libra
     * support copy with array containing primitive types. e.g. `String[]` => `String[]`
     * support copy with array type. e.g. `BeanA[]` => `BeanB[]`
     * support copy with property name mapping. e.g. `int id => int userId`
-    * support copy with recursion copy
-    * support validation through annotations
-    * support copy of beans with different field's name
-    * support lambda function field transformation
+    * support copy with recursion copy.
+    * support validation through annotations.
+    * support copy of beans with different field's name.
+    * support lambda function field transformation.
     * easy usage, declarative way to define the property mapping (in case of different names) or simply adding the lombok annotations.
     * allows to set the default value for all objects not existing in the source object.
+    * allows to skip transformation for a given set of fields.
+

--- a/docs/site/markdown/transformer/samples.md
+++ b/docs/site/markdown/transformer/samples.md
@@ -320,4 +320,57 @@ ToBean toBean = new ToBean();
 beanUtils.getTransformer().transform(fromBean, toBean);
 ~~~
 
+### Skip transformation on a given set of fields:
+
+Given:
+
+~~~Java
+public class FromBean {                                     public class ToBean {                           
+   private final String name;                                  private String name;                   
+   private final FromSubBean nestedObject;                     private ToSubBean nestedObject;                    
+
+   // all args constructor                                     // constructor
+   // getters...                                               // getters and setters...
+}                                                           }
+
+public class FromBean2 {                   
+   private final int index;             
+   private final FromSubBean nestedObject;
+                                          
+   // all args constructor                
+   // getters...                          
+}                                         
+~~~
+if you need to skip the transformation for a given field, just do:
+~~~Java
+ToBean toBean = new ToBean();
+beanUtils.getTransformer()
+    .skipTransformationForField("nestedObject")
+    .transform(fromBean, toBean);
+~~~
+
+where `nestedObject` is the name of the field in the destination object.
+
+This feature allows to **transform an object keeping the data from different sources**.
+
+To better explain this function let's assume that the `ToBean` (defined above) should be transformed as follow:
+- `name` field value has be taken from the `FromBean` object
+- `nestedObject` field value has be taken from the `FromBean2` object
+
+the objective can be reached by doing:
+~~~Java
+// create the destination object
+ToBean toBean = new ToBean();
+
+// execute the first transformation skipping the copy of: 'nestedObject' field that should come from the other source object
+beanUtils.getTransformer()
+    .skipTransformationForField("nestedObject")
+    .transform(fromBean, toBean);
+
+// then execute the transformation skipping the copy of: 'name' field that should come from the other source object
+beanUtils.getTransformer()
+    .skipTransformationForField("name")
+    .transform(fromBean2, toBean);
+~~~
+
 More sample beans can be found in the test package: `com.hotels.beans.sample`

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.hotels.beans</groupId>
 	<artifactId>bean-utils-library</artifactId>
 	<url>https://github.com/HotelsDotCom/bull</url>
-	<version>1.1.9-SNAPSHOT</version>
+	<version>1.2.3-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<inceptionYear>2019</inceptionYear>
 	<description>
@@ -22,7 +22,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<jdk.version>1.8</jdk.version>
+		<jdk.version>11</jdk.version>
 		<maven.compiler.source>${jdk.version}</maven.compiler.source>
 		<maven.compiler.target>${jdk.version}</maven.compiler.target>
 		<maven.pmd.plugin.version>3.11.0</maven.pmd.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>${maven.surefire.plugin.version}</version>
 				<configuration>
-					<parallelMavenExecution>true</parallelMavenExecution>
+					<parallelMavenExecution>false</parallelMavenExecution>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.hotels.beans</groupId>
 	<artifactId>bean-utils-library</artifactId>
 	<url>https://github.com/HotelsDotCom/bull</url>
-	<version>1.1.8-SNAPSHOT</version>
+	<version>1.1.8</version>
 	<packaging>jar</packaging>
 	<inceptionYear>2019</inceptionYear>
 	<description>
@@ -57,7 +57,7 @@
 		<connection>scm:git:git@github.com:HotelsDotCom/bull.git</connection>
 		<developerConnection>scm:git:git@github.com:HotelsDotCom/bull.git</developerConnection>
 		<url>https://github.com/HotelsDotCom/bull</url>
-		<tag>HEAD</tag>
+		<tag>1.1.8</tag>
   	</scm>
 	<distributionManagement>
 		<snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.hotels.beans</groupId>
 	<artifactId>bean-utils-library</artifactId>
 	<url>https://github.com/HotelsDotCom/bull</url>
-	<version>1.1.8</version>
+	<version>1.1.9-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<inceptionYear>2019</inceptionYear>
 	<description>
@@ -57,7 +57,7 @@
 		<connection>scm:git:git@github.com:HotelsDotCom/bull.git</connection>
 		<developerConnection>scm:git:git@github.com:HotelsDotCom/bull.git</developerConnection>
 		<url>https://github.com/HotelsDotCom/bull</url>
-		<tag>1.1.8</tag>
+		<tag>HEAD</tag>
   	</scm>
 	<distributionManagement>
 		<snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.hotels.beans</groupId>
 	<artifactId>bean-utils-library</artifactId>
 	<url>https://github.com/HotelsDotCom/bull</url>
-	<version>1.2.3-SNAPSHOT</version>
+	<version>1.1.8-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<inceptionYear>2019</inceptionYear>
 	<description>
@@ -22,7 +22,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<jdk.version>11</jdk.version>
+		<jdk.version>1.8</jdk.version>
 		<maven.compiler.source>${jdk.version}</maven.compiler.source>
 		<maven.compiler.target>${jdk.version}</maven.compiler.target>
 		<maven.pmd.plugin.version>3.11.0</maven.pmd.plugin.version>

--- a/src/main/java/com/hotels/beans/error/InvalidBeanException.java
+++ b/src/main/java/com/hotels/beans/error/InvalidBeanException.java
@@ -21,15 +21,6 @@ package com.hotels.beans.error;
  */
 public class InvalidBeanException extends RuntimeException {
     /**
-     * Constructs a new runtime exception with the specified detail message and
-     * cause.
-     * @param cause the given bean is not valid and caused an exception while copying the properties.
-     */
-    public InvalidBeanException(final Throwable cause) {
-        super(cause);
-    }
-
-    /**
      * Constructs a new invalid bean exception with the specified detail message.
      * The cause is not initialized, and may subsequently be initialized by a
      * call to {@link #initCause}.

--- a/src/main/java/com/hotels/beans/populator/Populator.java
+++ b/src/main/java/com/hotels/beans/populator/Populator.java
@@ -72,7 +72,7 @@ public abstract class Populator<O> {
      * @return a populated list of elements
      */
     public final <K> O getPopulatedObject(final Class<K> targetClass, final String fieldName, final O fieldValue) {
-        return getPopulatedObject(classUtils.getDeclaredField(targetClass, fieldName), fieldValue);
+        return getPopulatedObject(reflectionUtils.getDeclaredField(fieldName, targetClass), fieldValue);
     }
 
     /**

--- a/src/main/java/com/hotels/beans/transformer/AbstractTransformer.java
+++ b/src/main/java/com/hotels/beans/transformer/AbstractTransformer.java
@@ -16,6 +16,8 @@
 
 package com.hotels.beans.transformer;
 
+import static java.util.Arrays.asList;
+
 import static com.hotels.beans.utils.ValidationUtils.notNull;
 
 import java.util.Map;
@@ -185,6 +187,20 @@ abstract class AbstractTransformer implements Transformer {
         notNull(sourceObj, "The object to copy cannot be null!");
         notNull(targetObject, "The destination object cannot be null!");
         transform(sourceObj, targetObject, null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Transformer skipTransformationForField(final String... fieldName) {
+        settings.getFieldsToSkip().addAll(asList(fieldName));
+        return this;
+    }
+
+    @Override
+    public void resetFieldsTransformationSkip() {
+        settings.getFieldsToSkip().clear();
     }
 
     /**

--- a/src/main/java/com/hotels/beans/transformer/AbstractTransformer.java
+++ b/src/main/java/com/hotels/beans/transformer/AbstractTransformer.java
@@ -194,7 +194,9 @@ abstract class AbstractTransformer implements Transformer {
      */
     @Override
     public Transformer skipTransformationForField(final String... fieldName) {
-        settings.getFieldsToSkip().addAll(asList(fieldName));
+        if (fieldName.length != 0) {
+            settings.getFieldsToSkip().addAll(asList(fieldName));
+        }
         return this;
     }
 

--- a/src/main/java/com/hotels/beans/transformer/Transformer.java
+++ b/src/main/java/com/hotels/beans/transformer/Transformer.java
@@ -105,4 +105,16 @@ public interface Transformer {
      * @return the {@link Transformer} instance
      */
     Transformer setValidationDisabled(boolean validationDisabled);
+
+    /**
+     * Allows to specify all the fields for which the transformation have to be skipped.
+     * @param fieldName the destination object's fields names
+     * @return the {@link Transformer} instance
+     */
+    Transformer skipTransformationForField(String... fieldName);
+
+    /**
+     * Removes all the configured fields to skip.
+     */
+    void resetFieldsTransformationSkip();
 }

--- a/src/main/java/com/hotels/beans/transformer/Transformer.java
+++ b/src/main/java/com/hotels/beans/transformer/Transformer.java
@@ -108,7 +108,7 @@ public interface Transformer {
 
     /**
      * Allows to specify all the fields for which the transformation have to be skipped.
-     * @param fieldName the destination object's fields names
+     * @param fieldName the destination object's field(s) name that have to be skipped
      * @return the {@link Transformer} instance
      */
     Transformer skipTransformationForField(String... fieldName);

--- a/src/main/java/com/hotels/beans/transformer/TransformerImpl.java
+++ b/src/main/java/com/hotels/beans/transformer/TransformerImpl.java
@@ -172,7 +172,7 @@ public class TransformerImpl extends AbstractTransformer {
                     } else {
                         String sourceFieldName = getSourceFieldName(destFieldName);
                         constructorArgsValues[i] =
-                                ofNullable(getFieldValue(sourceObj, sourceFieldName, targetClass, classUtils.getDeclaredField(targetClass, destFieldName), breadcrumb))
+                                ofNullable(getFieldValue(sourceObj, sourceFieldName, targetClass, reflectionUtils.getDeclaredField(destFieldName, targetClass), breadcrumb))
                                 .orElse(classUtils.getDefaultTypeValue(constructorParameters[i].getType()));
                     }
                 });

--- a/src/main/java/com/hotels/beans/transformer/TransformerImpl.java
+++ b/src/main/java/com/hotels/beans/transformer/TransformerImpl.java
@@ -180,6 +180,15 @@ public class TransformerImpl extends AbstractTransformer {
     }
 
     /**
+     * Checks if a field has to be transformed or not.
+     * @param breadcrumb the field path
+     * @return true if the transformation has to be applied on this field, false in it has to be skipped.
+     */
+    private boolean doSkipTransformation(final String breadcrumb) {
+        return settings.getFieldsToSkip().contains(breadcrumb);
+    }
+
+    /**
      * Returns the field name in the source object.
      * @param field the field that has to be valorized.
      * @return the source field name.
@@ -300,6 +309,9 @@ public class TransformerImpl extends AbstractTransformer {
      */
     private <T, K> Object getFieldValue(final T sourceObj, final String sourceFieldName, final Class<K> targetClass, final Field field, final String breadcrumb) {
         String fieldBreadcrumb = evalBreadcrumb(field.getName(), breadcrumb);
+        if (doSkipTransformation(fieldBreadcrumb)) {
+            return defaultValue(field.getType());
+        }
         boolean primitiveType = classUtils.isPrimitiveType(field.getType());
         boolean isFieldTransformerDefined = settings.getFieldsTransformers().containsKey(field.getName());
         Object fieldValue = getSourceFieldValue(sourceObj, sourceFieldName, field, isFieldTransformerDefined);

--- a/src/main/java/com/hotels/beans/transformer/TransformerSettings.java
+++ b/src/main/java/com/hotels/beans/transformer/TransformerSettings.java
@@ -16,7 +16,9 @@
 
 package com.hotels.beans.transformer;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
@@ -46,6 +48,11 @@ final class TransformerSettings {
      * }
      */
     private final Map<String, Function<Object, Object>> fieldsTransformers = new ConcurrentHashMap<>();
+
+    /**
+     * Contains the list of fields that don't need to be transformed.
+     */
+    private final Set<String> fieldsToSkip = new HashSet<>();
 
     /**
      * It allows to configure the transformer in order to set a default value in case some field is missing in the source object.

--- a/src/main/java/com/hotels/beans/utils/ClassUtils.java
+++ b/src/main/java/com/hotels/beans/utils/ClassUtils.java
@@ -58,7 +58,6 @@ import java.util.stream.Stream;
 import com.hotels.beans.cache.CacheManager;
 import com.hotels.beans.constant.ClassType;
 import com.hotels.beans.error.InvalidBeanException;
-import com.hotels.beans.error.MissingFieldException;
 
 /**
  * Reflection utils for Class objects.
@@ -335,35 +334,6 @@ public final class ClassUtils {
             Field[] res = clazz.getDeclaredFields();
             cacheManager.cacheObject(cacheKey, res);
             return res;
-        });
-    }
-
-    /**
-     * Returns the class field.
-     * @param targetClass the class containing the field.
-     * @param fieldName the field name
-     * @param <K> the object type
-     * @return the class or superclass field
-     * @throws IllegalArgumentException {@link IllegalArgumentException} if the target class doesn't have such field
-     */
-    public <K> Field getDeclaredField(final Class<K> targetClass, final String fieldName) {
-        final String cacheKey = "ClassDeclaredField-" + targetClass.getCanonicalName() + '-' + fieldName;
-        return ofNullable(cacheManager.getFromCache(cacheKey, Field.class)).orElseGet(() -> {
-            Field field;
-            try {
-                field = targetClass.getDeclaredField(fieldName);
-            } catch (final NoSuchFieldException e) {
-                if (nonNull(targetClass.getSuperclass()) && !targetClass.getSuperclass().equals(Object.class)) {
-                    field = getDeclaredField(targetClass.getSuperclass(), fieldName);
-                } else {
-                    throw new MissingFieldException(
-                            "The field " + fieldName + " not exists in class: + " + targetClass.getCanonicalName()
-                                    + ". If the field in the source object has a different name please specify the "
-                                    + "transformation mapping.");
-                }
-            }
-            cacheManager.cacheObject(cacheKey, field);
-            return field;
         });
     }
 

--- a/src/main/java/com/hotels/beans/utils/ReflectionUtils.java
+++ b/src/main/java/com/hotels/beans/utils/ReflectionUtils.java
@@ -248,6 +248,8 @@ public final class ReflectionUtils {
      * @return the field corresponding to the given name.
      */
     public Field getDeclaredField(final String fieldName, final Class<?> targetClass) {
+//        final String cacheKey = "ClassDeclaredField-" + targetClass.getCanonicalName() + '-' + fieldName;
+//        return ofNullable(cacheManager.getFromCache(cacheKey, Field.class)).orElseGet(() -> {
         Field field;
         try {
             field = targetClass.getDeclaredField(fieldName);
@@ -261,7 +263,9 @@ public final class ReflectionUtils {
             handleReflectionException(e);
             throw new IllegalStateException(e);
         }
+//            cacheManager.cacheObject(cacheKey, field);
         return field;
+//        });
     }
 
     /**

--- a/src/main/java/com/hotels/beans/utils/ReflectionUtils.java
+++ b/src/main/java/com/hotels/beans/utils/ReflectionUtils.java
@@ -248,8 +248,6 @@ public final class ReflectionUtils {
      * @return the field corresponding to the given name.
      */
     public Field getDeclaredField(final String fieldName, final Class<?> targetClass) {
-//        final String cacheKey = "ClassDeclaredField-" + targetClass.getCanonicalName() + '-' + fieldName;
-//        return ofNullable(cacheManager.getFromCache(cacheKey, Field.class)).orElseGet(() -> {
         Field field;
         try {
             field = targetClass.getDeclaredField(fieldName);
@@ -263,9 +261,7 @@ public final class ReflectionUtils {
             handleReflectionException(e);
             throw new IllegalStateException(e);
         }
-//            cacheManager.cacheObject(cacheKey, field);
         return field;
-//        });
     }
 
     /**

--- a/src/main/java/com/hotels/beans/utils/ReflectionUtils.java
+++ b/src/main/java/com/hotels/beans/utils/ReflectionUtils.java
@@ -223,7 +223,7 @@ public final class ReflectionUtils {
         boolean isAccessible = true;
         Field field = null;
         try {
-            field = getDeclaredField(fieldName, target);
+            field = getDeclaredField(fieldName, target.getClass());
             isAccessible = isFieldAccessible(field, target);
             if (!isAccessible) {
                 field.setAccessible(true);
@@ -244,12 +244,11 @@ public final class ReflectionUtils {
     /**
      * Return the field of the given class.
      * @param fieldName the name of the filed to retrieve.
-     * @param target    the field's class
+     * @param targetClass the field's class
      * @return the field corresponding to the given name.
      */
-    private Field getDeclaredField(final String fieldName, final Object target) {
+    public Field getDeclaredField(final String fieldName, final Class<?> targetClass) {
         Field field;
-        Class<?> targetClass = target instanceof Class ? (Class<?>) target : target.getClass();
         try {
             field = targetClass.getDeclaredField(fieldName);
         } catch (NoSuchFieldException e) {

--- a/src/test/java/com/hotels/beans/transformer/ImmutableObjectTransformationTest.java
+++ b/src/test/java/com/hotels/beans/transformer/ImmutableObjectTransformationTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -457,6 +458,24 @@ public class ImmutableObjectTransformationTest extends AbstractTransformerTest {
 
         //THEN
         assertThat(immutableObjectBean, hasProperty(AGE_FIELD_NAME, equalTo(AGE)));
+    }
+
+    /**
+     * Test that, given a set of fields for which the transformation has to be skipped, they are actually skipped.
+     */
+    @Test
+    public void testFieldTransformationSkipWorksProperly() {
+        //GIVEN
+        underTest.skipTransformationForField("name", "nestedObject.phoneNumbers");
+
+        //WHEN
+        ImmutableToFoo actual = underTest.transform(fromFoo, ImmutableToFoo.class);
+
+        //THEN
+        assertEquals(fromFoo.getId(), actual.getId());
+        assertNull(actual.getName());
+        assertNull(actual.getNestedObject().getPhoneNumbers());
+        underTest.resetFieldsTransformationSkip();
     }
 
     /**

--- a/src/test/java/com/hotels/beans/transformer/MixedObjectTransformationTest.java
+++ b/src/test/java/com/hotels/beans/transformer/MixedObjectTransformationTest.java
@@ -178,6 +178,24 @@ public class MixedObjectTransformationTest extends AbstractTransformerTest {
     }
 
     /**
+     * Test that, given a set of fields for which the transformation has to be skipped, they are actually skipped.
+     */
+    @Test
+    public void testFieldTransformationSkipWorksProperly() {
+        //GIVEN
+        underTest.skipTransformationForField(NAME_FIELD_NAME, PHONE_NUMBER_NESTED_OBJECT_FIELD_NAME);
+
+        //WHEN
+        MixedToFoo actual = underTest.transform(fromFoo, MixedToFoo.class);
+
+        //THEN
+        assertEquals(fromFoo.getId(), actual.getId());
+        assertNull(actual.getName());
+        assertNull(actual.getNestedObject().getPhoneNumbers());
+        underTest.resetFieldsTransformationSkip();
+    }
+
+    /**
      * Test transformation on an existing bean is correctly copied.
      */
     @Test

--- a/src/test/java/com/hotels/beans/transformer/MutableObjectTransformationTest.java
+++ b/src/test/java/com/hotels/beans/transformer/MutableObjectTransformationTest.java
@@ -19,6 +19,7 @@ package com.hotels.beans.transformer;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -168,5 +169,23 @@ public class MutableObjectTransformationTest extends AbstractTransformerTest {
 
         //THEN
         assertThat(mutableObjectBean, hasProperty(AGE_FIELD_NAME, equalTo(AGE)));
+    }
+
+    /**
+     * Test that, given a set of fields for which the transformation has to be skipped, they are actually skipped.
+     */
+    @Test
+    public void testFieldTransformationSkipWorksProperly() {
+        //GIVEN
+        underTest.skipTransformationForField(NAME_FIELD_NAME, PHONE_NUMBER_NESTED_OBJECT_FIELD_NAME);
+
+        //WHEN
+        MutableToFoo actual = underTest.transform(fromFoo, MutableToFoo.class);
+
+        //THEN
+        assertEquals(fromFoo.getId(), actual.getId());
+        assertNull(actual.getName());
+        assertNull(actual.getNestedObject().getPhoneNumbers());
+        underTest.resetFieldsTransformationSkip();
     }
 }

--- a/src/test/java/com/hotels/beans/utils/ClassUtilsTest.java
+++ b/src/test/java/com/hotels/beans/utils/ClassUtilsTest.java
@@ -356,21 +356,6 @@ public class ClassUtilsTest {
     }
 
     /**
-     * Tests that the method {@code getDeclaredFields} returns the expected field.
-     */
-    @Test
-    public void testGetDeclaredFieldReturnsTheExpectedField() {
-        // GIVEN
-
-        // WHEN
-        Field actual = underTest.getDeclaredField(CLASS_WITH_STATIC_FIELDS, NORMAL_FIELD);
-
-        // THEN
-        assertNotNull(actual);
-        assertEquals(NORMAL_FIELD, actual.getName());
-    }
-
-    /**
      * Tests that the method {@code getAllArgsConstructor} returns the class constructor.
      */
     @Test


### PR DESCRIPTION
# Transformation skip on a given set of fields

## Description

Implemented a new feature that allows to skip the transformation for a given set of fields.
The perfect scenario for this would be the case of copy on existing destination objects

Fixes # 38

## How Has This Been Tested?

- [X] Transformation is skipped on a given field
- [X] Transformation is not skipped if no fields are specified

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] My changes have no bad impacts on performances
