### PR TITLE
Fix when transformerFunction is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+### [1.2.7] TBD
+#### Fixed
+* Fixed issue when returning null in a field tranformer
+
 ### [1.2.6] 2019.04.06
 #### Added
 * Implemented possibility to use static transformation with a given transformer (see: [Issue 44](https://github.com/HotelsDotCom/bull/issues/44)).

--- a/src/main/java/com/hotels/beans/transformer/TransformerImpl.java
+++ b/src/main/java/com/hotels/beans/transformer/TransformerImpl.java
@@ -39,6 +39,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Parameter;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 import com.hotels.beans.annotation.ConstructorArg;
 import com.hotels.beans.constant.ClassType;
@@ -377,9 +378,8 @@ public class TransformerImpl extends AbstractTransformer {
      */
     private Object getTransformedField(final Field field, final String breadcrumb, final Object fieldValue) {
         String fieldName = settings.isFlatFieldNameTransformation() ? field.getName() : breadcrumb;
-        return ofNullable(settings.getFieldsTransformers().get(fieldName))
-                .map(fieldTransformer -> fieldTransformer.apply(fieldValue))
-                .orElse(fieldValue);
+        Function<Object, Object> transformerFunction = settings.getFieldsTransformers().get(fieldName);
+        return nonNull(transformerFunction) ? transformerFunction.apply(fieldValue) : fieldValue;
     }
 
     /**


### PR DESCRIPTION
# Pull Request Template

## Description
In the getTransformedField method there was a bug that could cause an InvalidBeanException.
In this portion of code

```
return ofNullable(settings.getFieldsTransformers().get(fieldName))
                 .map(fieldTransformer -> fieldTransformer.apply(fieldValue))
                 .orElse(fieldValue);
```

when the expression "fieldTransformer.apply(fieldValue)" is null, it returns the "fieldValue" value. That's not correct if i want the interested field as null in the response.

## How Has This Been Tested?

I tested it with a `fieldTrasformer<List<MyObject>,String>`. I wasn't able to return a "null" value on the fieldTransformer.
After the change, you are now able to return a null value on a fieldTransformer in order to have a null field in your response.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] My changes have no bad impacts on performances
