### PR TITLE
changed logic to pass original values to FieldTransformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+### [1.4.1.2] 2019.05.24
+#### Changes
+* Fixed a bug: FieldTransformer was receiving a default value instead of the source bean one (see: [Issue 64](https://github.com/HotelsDotCom/bull/issues/64)).
+
 ### [1.4.1.1] 2019.05.24
 #### Changes
 * Made the project multi module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-### [1.4.1.2] 2019.05.24
+### [1.4.2] 2019.05.24
 #### Changes
 * Fixed a bug: FieldTransformer was receiving a default value instead of the source bean one (see: [Issue 64](https://github.com/HotelsDotCom/bull/issues/64)).
 

--- a/bean-utils-library/src/main/java/com/hotels/beans/transformer/TransformerImpl.java
+++ b/bean-utils-library/src/main/java/com/hotels/beans/transformer/TransformerImpl.java
@@ -315,21 +315,22 @@ public class TransformerImpl extends AbstractTransformer {
         Function<Object, Object> transformerFunction = getTransformerFunction(field, fieldBreadcrumb);
         boolean isTransformerFunctionDefined = nonNull(transformerFunction);
         Object fieldValue = getSourceFieldValue(sourceObj, sourceFieldName, isTransformerFunctionDefined);
+        Object outputValue = fieldValue;
         if (nonNull(fieldValue)) {
             // is not a primitive type or an optional && there are no transformer function
             // defined it recursively evaluate the value
             boolean notPrimitiveAndNotSpecialType = !primitiveType && !classUtils.isSpecialType(fieldType);
             if (!isTransformerFunctionDefined
                     && (notPrimitiveAndNotSpecialType || Optional.class.isAssignableFrom(fieldValue.getClass()))) {
-                fieldValue = getFieldValue(targetClass, field, fieldValue, fieldBreadcrumb);
+                outputValue = getFieldValue(targetClass, field, fieldValue, fieldBreadcrumb);
             }
         } else if (primitiveType) {
-            fieldValue = defaultValue(fieldType); // assign the default value
+            outputValue = defaultValue(fieldType); // assign the default value
         }
         if (isTransformerFunctionDefined) {
-            fieldValue = transformerFunction.apply(fieldValue);
+            outputValue = transformerFunction.apply(fieldValue);
         }
-        return fieldValue;
+        return outputValue;
     }
 
     /**

--- a/bean-utils-library/src/main/java/com/hotels/beans/transformer/TransformerImpl.java
+++ b/bean-utils-library/src/main/java/com/hotels/beans/transformer/TransformerImpl.java
@@ -315,22 +315,21 @@ public class TransformerImpl extends AbstractTransformer {
         Function<Object, Object> transformerFunction = getTransformerFunction(field, fieldBreadcrumb);
         boolean isTransformerFunctionDefined = nonNull(transformerFunction);
         Object fieldValue = getSourceFieldValue(sourceObj, sourceFieldName, isTransformerFunctionDefined);
-        Object outputValue = fieldValue;
         if (nonNull(fieldValue)) {
             // is not a primitive type or an optional && there are no transformer function
             // defined it recursively evaluate the value
             boolean notPrimitiveAndNotSpecialType = !primitiveType && !classUtils.isSpecialType(fieldType);
             if (!isTransformerFunctionDefined
-                    && (notPrimitiveAndNotSpecialType || Optional.class.isAssignableFrom(fieldValue.getClass()))) {
-                outputValue = getFieldValue(targetClass, field, fieldValue, fieldBreadcrumb);
+                && (notPrimitiveAndNotSpecialType || Optional.class.isAssignableFrom(fieldValue.getClass()))) {
+                fieldValue = getFieldValue(targetClass, field, fieldValue, fieldBreadcrumb);
             }
-        } else if (primitiveType) {
-            outputValue = defaultValue(fieldType); // assign the default value
+        } else if (!isTransformerFunctionDefined && primitiveType) {
+            fieldValue = defaultValue(fieldType); // assign the default value
         }
         if (isTransformerFunctionDefined) {
-            outputValue = transformerFunction.apply(fieldValue);
+            fieldValue = transformerFunction.apply(fieldValue);
         }
-        return outputValue;
+        return fieldValue;
     }
 
     /**

--- a/bean-utils-library/src/test/java/com/hotels/beans/BeanUtilsTest.java
+++ b/bean-utils-library/src/test/java/com/hotels/beans/BeanUtilsTest.java
@@ -16,11 +16,12 @@
 
 package com.hotels.beans;
 
-import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.MockitoAnnotations.initMocks;
+
+import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs;
 
 import java.math.BigInteger;
 import java.util.Arrays;

--- a/bean-utils-library/src/test/java/com/hotels/beans/BeanUtilsTest.java
+++ b/bean-utils-library/src/test/java/com/hotels/beans/BeanUtilsTest.java
@@ -16,11 +16,11 @@
 
 package com.hotels.beans;
 
+import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.MockitoAnnotations.initMocks;
-
-import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs;
 
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -35,10 +35,13 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.hotels.beans.error.InvalidBeanException;
+import com.hotels.beans.model.FieldTransformer;
 import com.hotels.beans.sample.FromFooSimple;
+import com.hotels.beans.sample.FromFooSimpleBooleanField;
 import com.hotels.beans.sample.immutable.ImmutableToFoo;
 import com.hotels.beans.sample.immutable.ImmutableToFooMissingCustomAnnotation;
 import com.hotels.beans.sample.immutable.ImmutableToFooSimple;
+import com.hotels.beans.sample.immutable.ImmutableToFooSimpleBoolean;
 import com.hotels.beans.transformer.Transformer;
 
 /**
@@ -110,6 +113,26 @@ public class BeanUtilsTest {
     }
 
     /**
+     * Test that the transformer function is applied earlier than the default value
+     */
+    @Test
+    public void testTransformerFunctionHasHigherPriorityThanDefaultValue() {
+        //GIVEN
+        BeanUtils beanUtils = new BeanUtils();
+        FromFooSimpleBooleanField fromFooSimpleNullFields = createFromFooSimpleNullFields();
+        FieldTransformer<Boolean, Boolean> nullToTrue =
+                new FieldTransformer<>("work", aBoolean -> aBoolean == null || aBoolean);
+
+        //WHEN
+        ImmutableToFooSimpleBoolean transformed = beanUtils.getTransformer()
+                .withFieldTransformer(nullToTrue)
+                .transform(fromFooSimpleNullFields, ImmutableToFooSimpleBoolean.class);
+
+        //THEN
+        assertTrue(transformed.getWork());
+    }
+
+    /**
      * Creates the parameters to be used for testing the default transformation operations.
      * @return parameters to be used for testing the default transformation operations.
      */
@@ -156,5 +179,13 @@ public class BeanUtilsTest {
      */
     private FromFooSimple createFromFooSimple() {
         return new FromFooSimple(NAME, ID);
+    }
+
+    /**
+     * Creates a {@link FromFooSimpleBooleanField} instance with null field.
+     * @return the {@link FromFooSimpleBooleanField} instance.
+     */
+    private FromFooSimpleBooleanField createFromFooSimpleNullFields() {
+        return new FromFooSimpleBooleanField();
     }
 }

--- a/bean-utils-library/src/test/java/com/hotels/beans/BeanUtilsTest.java
+++ b/bean-utils-library/src/test/java/com/hotels/beans/BeanUtilsTest.java
@@ -18,7 +18,6 @@ package com.hotels.beans;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs;
@@ -36,13 +35,10 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.hotels.beans.error.InvalidBeanException;
-import com.hotels.beans.model.FieldTransformer;
 import com.hotels.beans.sample.FromFooSimple;
-import com.hotels.beans.sample.FromFooSimpleBooleanField;
 import com.hotels.beans.sample.immutable.ImmutableToFoo;
 import com.hotels.beans.sample.immutable.ImmutableToFooMissingCustomAnnotation;
 import com.hotels.beans.sample.immutable.ImmutableToFooSimple;
-import com.hotels.beans.sample.immutable.ImmutableToFooSimpleBoolean;
 import com.hotels.beans.transformer.Transformer;
 
 /**
@@ -114,26 +110,6 @@ public class BeanUtilsTest {
     }
 
     /**
-     * Test that the transformer function is applied earlier than the default value
-     */
-    @Test
-    public void testTransformerFunctionHasHigherPriorityThanDefaultValue() {
-        //GIVEN
-        BeanUtils beanUtils = new BeanUtils();
-        FromFooSimpleBooleanField fromFooSimpleNullFields = createFromFooSimpleNullFields();
-        FieldTransformer<Boolean, Boolean> nullToTrue =
-                new FieldTransformer<>("work", aBoolean -> aBoolean == null || aBoolean);
-
-        //WHEN
-        ImmutableToFooSimpleBoolean transformed = beanUtils.getTransformer()
-                .withFieldTransformer(nullToTrue)
-                .transform(fromFooSimpleNullFields, ImmutableToFooSimpleBoolean.class);
-
-        //THEN
-        assertTrue(transformed.getWork());
-    }
-
-    /**
      * Creates the parameters to be used for testing the default transformation operations.
      * @return parameters to be used for testing the default transformation operations.
      */
@@ -182,11 +158,4 @@ public class BeanUtilsTest {
         return new FromFooSimple(NAME, ID);
     }
 
-    /**
-     * Creates a {@link FromFooSimpleBooleanField} instance with null field.
-     * @return the {@link FromFooSimpleBooleanField} instance.
-     */
-    private FromFooSimpleBooleanField createFromFooSimpleNullFields() {
-        return new FromFooSimpleBooleanField();
-    }
 }

--- a/bean-utils-library/src/test/java/com/hotels/beans/transformer/ImmutableObjectTransformationTest.java
+++ b/bean-utils-library/src/test/java/com/hotels/beans/transformer/ImmutableObjectTransformationTest.java
@@ -500,12 +500,12 @@ public class ImmutableObjectTransformationTest extends AbstractTransformerTest {
             new FieldTransformer<>("work", aBoolean -> aBoolean == null || aBoolean);
 
         //WHEN
-        ImmutableToFooSimpleBoolean transformed = beanUtils.getTransformer()
+        ImmutableToFooSimpleBoolean actual = beanUtils.getTransformer()
             .withFieldTransformer(nullToTrue)
             .transform(fromFooSimpleNullFields, ImmutableToFooSimpleBoolean.class);
 
         //THEN
-        assertTrue(transformed.getWork());
+        assertTrue(actual.getWork());
     }
 
     /**

--- a/bean-utils-library/src/test/java/com/hotels/beans/transformer/ImmutableObjectTransformationTest.java
+++ b/bean-utils-library/src/test/java/com/hotels/beans/transformer/ImmutableObjectTransformationTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -53,6 +54,7 @@ import com.hotels.beans.model.FieldTransformer;
 import com.hotels.beans.sample.FromFoo;
 import com.hotels.beans.sample.FromFooAdvFields;
 import com.hotels.beans.sample.FromFooSimple;
+import com.hotels.beans.sample.FromFooSimpleBooleanField;
 import com.hotels.beans.sample.immutable.ImmutableFlatToFoo;
 import com.hotels.beans.sample.immutable.ImmutableToFoo;
 import com.hotels.beans.sample.immutable.ImmutableToFooAdvFields;
@@ -63,6 +65,7 @@ import com.hotels.beans.sample.immutable.ImmutableToFooMap;
 import com.hotels.beans.sample.immutable.ImmutableToFooMissingCustomAnnotation;
 import com.hotels.beans.sample.immutable.ImmutableToFooNotExistingFields;
 import com.hotels.beans.sample.immutable.ImmutableToFooSimple;
+import com.hotels.beans.sample.immutable.ImmutableToFooSimpleBoolean;
 import com.hotels.beans.sample.immutable.ImmutableToFooSimpleWrongTypes;
 import com.hotels.beans.sample.immutable.ImmutableToFooSubClass;
 import com.hotels.beans.utils.ReflectionUtils;
@@ -483,6 +486,26 @@ public class ImmutableObjectTransformationTest extends AbstractTransformerTest {
         assertNull(actual.getName());
         assertNull(actual.getNestedObject().getPhoneNumbers());
         underTest.resetFieldsTransformationSkip();
+    }
+
+    /**
+     * Test that the transformer function is applied earlier than the default value
+     */
+    @Test
+    public void testTransformerFunctionHasHigherPriorityThanDefaultValue() {
+        //GIVEN
+        BeanUtils beanUtils = new BeanUtils();
+        FromFooSimpleBooleanField fromFooSimpleNullFields = new FromFooSimpleBooleanField();
+        FieldTransformer<Boolean, Boolean> nullToTrue =
+            new FieldTransformer<>("work", aBoolean -> aBoolean == null || aBoolean);
+
+        //WHEN
+        ImmutableToFooSimpleBoolean transformed = beanUtils.getTransformer()
+            .withFieldTransformer(nullToTrue)
+            .transform(fromFooSimpleNullFields, ImmutableToFooSimpleBoolean.class);
+
+        //THEN
+        assertTrue(transformed.getWork());
     }
 
     /**

--- a/bean-utils-library/src/test/java/com/hotels/beans/transformer/ImmutableObjectTransformationTest.java
+++ b/bean-utils-library/src/test/java/com/hotels/beans/transformer/ImmutableObjectTransformationTest.java
@@ -494,18 +494,18 @@ public class ImmutableObjectTransformationTest extends AbstractTransformerTest {
     @Test
     public void testTransformerFunctionHasHigherPriorityThanDefaultValue() {
         //GIVEN
-        BeanUtils beanUtils = new BeanUtils();
         FromFooSimpleBooleanField fromFooSimpleNullFields = new FromFooSimpleBooleanField();
         FieldTransformer<Boolean, Boolean> nullToTrue =
             new FieldTransformer<>("work", aBoolean -> aBoolean == null || aBoolean);
 
         //WHEN
-        ImmutableToFooSimpleBoolean actual = beanUtils.getTransformer()
+        ImmutableToFooSimpleBoolean actual = underTest
             .withFieldTransformer(nullToTrue)
             .transform(fromFooSimpleNullFields, ImmutableToFooSimpleBoolean.class);
 
         //THEN
         assertTrue(actual.getWork());
+        underTest.resetFieldsTransformer();
     }
 
     /**

--- a/bull-common/src/test/java/com/hotels/beans/sample/FromFooSimpleBooleanField.java
+++ b/bull-common/src/test/java/com/hotels/beans/sample/FromFooSimpleBooleanField.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2019 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hotels.beans.sample;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Sample immutable object with a {@link Boolean} field.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class FromFooSimpleBooleanField {
+    public Boolean work;
+
+    @Override
+    public String toString() {
+        return "FromFooSimpleBooleanField";
+    }
+}

--- a/bull-common/src/test/java/com/hotels/beans/sample/immutable/ImmutableToFooSimpleBoolean.java
+++ b/bull-common/src/test/java/com/hotels/beans/sample/immutable/ImmutableToFooSimpleBoolean.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.hotels.beans.sample.immutable;
 
 import lombok.AllArgsConstructor;

--- a/bull-common/src/test/java/com/hotels/beans/sample/immutable/ImmutableToFooSimpleBoolean.java
+++ b/bull-common/src/test/java/com/hotels/beans/sample/immutable/ImmutableToFooSimpleBoolean.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2019 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.beans.sample.immutable;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Sample immutable object.
+ */
+@AllArgsConstructor
+@Getter
+public class ImmutableToFooSimpleBoolean {
+    private final Boolean work;
+
+    @Override
+    public String toString() {
+        return "ImmutableToFooSimpleBoolean";
+    }
+}


### PR DESCRIPTION
## Description
Changed logic of `TransformerImpl.getFieldValue` to pass the original fieldValue to the `transformerFunction`. 

Fixes #64 

## How Has This Been Tested?

Added `BeanUtilsTest.testTransformerFunctionHasHigherPriorityThanDefaultValue`

## Checklist:

- [x] The branch follows the best practices naming convention:
     - Use grouping tokens (words) at the beginning of your branch names.
        * `feature`: Feature I'm adding or expanding
        * `bug`: Bug fix or experiment
        * `wip`: Work in progress; stuff I know won't be finished soon
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] My changes have no bad impacts on performances
- [x] Any implemented change has been added in the [CHANGELOG.md](./CHANGELOG.md) file 
