### PR TITLE
Disable the default value set for primitive types in case they are null

### DIFF
--- a/CHANGELOG-JDK8.md
+++ b/CHANGELOG-JDK8.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+### [1.1.22] 2019.07.03
+#### Added
+* Implemented possibility to disable the default value set for primitive types in case its value is null (see: [Issue 73](https://github.com/HotelsDotCom/bull/issues/73)).
+
 ### [1.1.21] 2019.06.27
 #### Changed
 * Improved exception messages in order to provide more details (see: [Issue 70](https://github.com/HotelsDotCom/bull/issues/70)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+### [1.4.7] 2019.07.03
+#### Added
+* Implemented possibility to disable the default value set for primitive types in case its value is null (see: [Issue 73](https://github.com/HotelsDotCom/bull/issues/73)).
+
 ### [1.4.6] 2019.06.27
 #### Changed
 * Improved exception messages in order to provide more details (see: [Issue 70](https://github.com/HotelsDotCom/bull/issues/70)).
 
 ### [1.4.5] 2019.06.05
+#### Added
 * Added new maven profile: `check-for-updates` for checking if any dependency can be updated (see: [Issue 68](https://github.com/HotelsDotCom/bull/issues/68)).
 * Added check during project build in order to prevent the add different versions of the same dependency.
 #### Changed

--- a/README.md
+++ b/README.md
@@ -256,6 +256,33 @@ ToBean toBean = beanUtils.getTransformer()
                     .setDefaultValueForMissingField(true).transform(fromBean, ToBean.class);
 ~~~
 
+### Disable the default value set for primitive types in case they are null:
+
+BULL by default sets the default value for all primitive types fields in case their value in the source object.
+Given the following Java Bean:
+
+~~~Java
+public class FromBean {                                     public class ToBean {                           
+   private final String name;                                  @NotNull                   
+   private final BigInteger id;                                public BigInteger id;                      
+                                                               private final String name;                 
+
+   // constructors...                                          // constructors...
+   // getters...                                               // getters and setters...
+
+}                                                           }
+~~~
+
+in case the field `id` in the `FromBean` object is `null`, the value assigned the correspondent field in the `ToBean` object will be `0`.
+To disable this you can simply do: 
+
+~~~Java
+ToBean toBean = beanUtils.getTransformer()
+                    .setDefaultValueSetEnabled(false).transform(fromBean, ToBean.class);
+~~~
+
+in this case the field `id` after the transformation will be `null`
+
 ### Applying a transformation function in case of missing fields in the source object:
 
 Assign a default value in case of missing field in the source object:

--- a/bean-utils-library/src/main/java/com/hotels/beans/transformer/AbstractTransformer.java
+++ b/bean-utils-library/src/main/java/com/hotels/beans/transformer/AbstractTransformer.java
@@ -161,6 +161,15 @@ abstract class AbstractTransformer implements Transformer {
      * {@inheritDoc}
      */
     @Override
+    public Transformer setDefaultValueSetEnabled(final boolean defaultValueSetEnabled) {
+        settings.setDefaultValueSetEnabled(defaultValueSetEnabled);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public final <T, K> K transform(final T sourceObj, final Class<? extends K> targetClass) {
         notNull(sourceObj, "The object to copy cannot be null!");
         notNull(targetClass, "The destination class cannot be null!");

--- a/bean-utils-library/src/main/java/com/hotels/beans/transformer/Transformer.java
+++ b/bean-utils-library/src/main/java/com/hotels/beans/transformer/Transformer.java
@@ -117,4 +117,11 @@ public interface Transformer {
      * Removes all the configured fields to skip.
      */
     void resetFieldsTransformationSkip();
+
+    /**
+     * It allows to enable/disable the set of the default value for primitive types in case they are null.
+     * @param defaultValueSetEnabled if true the default value for the primitive type is set. By default it's true.
+     * @return the {@link Transformer} instance
+     */
+    Transformer setDefaultValueSetEnabled(boolean defaultValueSetEnabled);
 }

--- a/bean-utils-library/src/main/java/com/hotels/beans/transformer/TransformerImpl.java
+++ b/bean-utils-library/src/main/java/com/hotels/beans/transformer/TransformerImpl.java
@@ -170,8 +170,7 @@ public class TransformerImpl extends AbstractTransformer {
                     } else {
                         String sourceFieldName = getSourceFieldName(destFieldName);
                         constructorArgsValues[i] =
-                                ofNullable(getFieldValue(sourceObj, sourceFieldName, targetClass, reflectionUtils.getDeclaredField(destFieldName, targetClass), breadcrumb))
-                                .orElse(classUtils.getDefaultTypeValue(constructorParameters[i].getType()));
+                                getFieldValue(sourceObj, sourceFieldName, targetClass, reflectionUtils.getDeclaredField(destFieldName, targetClass), breadcrumb);
                     }
                 });
         return constructorArgsValues;

--- a/bean-utils-library/src/main/java/com/hotels/beans/transformer/TransformerImpl.java
+++ b/bean-utils-library/src/main/java/com/hotels/beans/transformer/TransformerImpl.java
@@ -324,7 +324,7 @@ public class TransformerImpl extends AbstractTransformer {
                     && (notPrimitiveAndNotSpecialType || Optional.class.isAssignableFrom(fieldValue.getClass()))) {
                 fieldValue = getFieldValue(targetClass, field, fieldValue, fieldBreadcrumb);
             }
-        } else if (primitiveType && !isTransformerFunctionDefined) {
+        } else if (primitiveType && settings.isDefaultValueSetEnabled() && !isTransformerFunctionDefined) {
             fieldValue = defaultValue(fieldType); // assign the default value
         }
         if (isTransformerFunctionDefined) {

--- a/bean-utils-library/src/main/java/com/hotels/beans/transformer/TransformerSettings.java
+++ b/bean-utils-library/src/main/java/com/hotels/beans/transformer/TransformerSettings.java
@@ -75,4 +75,11 @@ final class TransformerSettings {
      */
     @Setter
     private boolean validationEnabled;
+
+    /**
+     * It allows to enable/disable the set of the default value for primitive types in case they are null.
+     * If set to true the default value is set.
+     */
+    @Setter
+    private boolean defaultValueSetEnabled = true;
 }

--- a/bean-utils-library/src/test/java/com/hotels/beans/transformer/MutableObjectTransformationTest.java
+++ b/bean-utils-library/src/test/java/com/hotels/beans/transformer/MutableObjectTransformationTest.java
@@ -176,6 +176,23 @@ public class MutableObjectTransformationTest extends AbstractTransformerTest {
     }
 
     /**
+     * Test that the transformer does not sets the default value for primitive type field in case it's disabled.
+     */
+    @Test
+    public void testTransformerDoesNotSetsTheDefaultValueForPrimitiveTypeField() {
+        //GIVEN
+        FromFooSimpleNoGetters fromFooSimpleNoGetters = new FromFooSimpleNoGetters(NAME, null, ACTIVE);
+        underTest.setDefaultValueSetEnabled(false);
+
+        //WHEN
+        MutableToFooSimpleNoSetters actual = underTest.transform(fromFooSimpleNoGetters, MutableToFooSimpleNoSetters.class);
+
+        //THEN
+        assertThat(actual, sameBeanAs(fromFooSimpleNoGetters));
+        underTest.setDefaultValueSetEnabled(true);
+    }
+
+    /**
      * Test that the transformer is able to copy object even if the source object has no fields but has getter methods.
      */
     @Test

--- a/docs/site/markdown/transformer/samples.md
+++ b/docs/site/markdown/transformer/samples.md
@@ -179,6 +179,33 @@ ToBean toBean = beanUtils.getTransformer()
                     .setDefaultValueForMissingField(true).transform(fromBean, ToBean.class);
 ~~~
 
+### Disable the default value set for primitive types in case they are null:
+
+BULL by default sets the default value for all primitive types fields in case their value in the source object.
+Given the following Java Bean:
+
+~~~Java
+public class FromBean {                                     public class ToBean {                           
+   private final String name;                                  @NotNull                   
+   private final BigInteger id;                                public BigInteger id;                      
+                                                               private final String name;                 
+
+   // constructors...                                          // constructors...
+   // getters...                                               // getters and setters...
+
+}                                                           }
+~~~
+
+in case the field `id` in the `FromBean` object is `null`, the value assigned the correspondent field in the `ToBean` object will be `0`.
+To disable this you can simply do: 
+
+~~~Java
+ToBean toBean = beanUtils.getTransformer()
+                    .setDefaultValueSetEnabled(false).transform(fromBean, ToBean.class);
+~~~
+
+in this case the field `id` after the transformation will be `null`
+
 ### Applying a transformation function in case of missing fields in the source object:
 
 Assign a default value in case of missing field in the source object:


### PR DESCRIPTION
# Pull Request Template

## Description

Implemented possibility to disable the "default value set" for primitive type fields in the destination objects in case their correspondent field in the source object is null.
The method introduced is: `setDefaultValueSetEnabled`

e.g.

```
ToBean toBean = beanUtils.getTransformer()
                    .setDefaultValueSetEnabled(false).transform(fromBean, ToBean.class);
```

Fixes # 73

## How Has This Been Tested?

- [X] By default it keeps the old behaviour
- [X] If disabled no default value is set leaving it to null

## Checklist:

- [X] The branch follows the best practices naming convention:
     - Use grouping tokens (words) at the beginning of your branch names.
        * `feature`: Feature I'm adding or expanding
        * `bug`: Bug fix or experiment
        * `wip`: Work in progress; stuff I know won't be finished soon
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] My changes have no bad impacts on performances
- [X] Any implemented change has been added in the [CHANGELOG.md](./CHANGELOG.md) file 
