### PR TITLE
JDK8 automatic release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: java
 cache:
   directories:
     - $HOME/.m2
-jdk:
-  - openjdk11
-  - openjdk8
 env:
   global:
     # HCOM OSS Sonatype jira info
@@ -20,22 +17,22 @@ jobs:
     ### JDK11 build
     - stage: "JDK11 Build"
       name: "JDK11 Build and Test"
+      jdk: openjdk11
       if: branch =~ ^((?!-jdk8).)*$ OR tag =~ ^((?!-jdk8).)*$
       script:
-        - jdk_switcher use openjdk11
         - travis_retry mvn clean install
     ### JDK8 build
     - stage: "JDK8 Build"
       name: "JDK8 Build and Test"
+      jdk: openjdk8
       if: branch =~ ^.*-jdk8$ OR tag =~ ^.*-jdk8$
       script:
-        - jdk_switcher use openjdk8
         - travis_retry mvn clean install
     - stage: "Site Build and Quality check"
       name: "Publishing site and performing a code quality check"
+      jdk: openjdk8
       if: type NOT IN (pull_request) AND tag IS present AND tag =~ ^((?!-jdk8).)*$
-      script:
-        - jdk_switcher use openjdk11
+      script: skip
       before_deploy:
         - mvn versions:set -D newVersion=${TRAVIS_TAG}
         - travis_retry mvn install sonar:sonar -Dsonar.projectKey=${sonar_project_key} -Dsonar.organization=${sonar_organization} -Dsonar.host.url=${sonar_host_url} -Dsonar.login=${sonar_token} site:site javadoc:aggregate -P default,site-release
@@ -50,9 +47,9 @@ jobs:
     ### JDK11 release
     - stage: "JDK11 Release"
       name: "Releasing artifacts for JDK11"
+      jdk: openjdk11
       if: type NOT IN (pull_request) AND tag IS present AND tag =~ ^((?!-jdk8).)*$
-      script:
-        - jdk_switcher use openjdk11
+      script: skip
       before_deploy:
         - openssl aes-256-cbc -K $encrypted_bbb0f94c13c1_key -iv $encrypted_bbb0f94c13c1_iv -in config/travis/private-key.gpg.enc -out config/travis/private-key.gpg -d
         - mvn versions:set -D newVersion=${TRAVIS_TAG}
@@ -66,9 +63,9 @@ jobs:
     ### JDK8 release
     - stage: "JDK8 Release"
       name: "Releasing artifacts for JDK8"
+      jdk: openjdk8
       if: type NOT IN (pull_request) AND tag IS present AND tag =~ ^.*-jdk8$
-      script:
-        - jdk_switcher use openjdk11
+      script: skip
       before_deploy:
         - openssl aes-256-cbc -K $encrypted_bbb0f94c13c1_key -iv $encrypted_bbb0f94c13c1_iv -in config/travis/private-key.gpg.enc -out config/travis/private-key.gpg -d
         - mvn versions:set -D newVersion=${TRAVIS_TAG}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: java
 cache:
   directories:
     - $HOME/.m2
-jdk:
-  - openjdk11
-  - openjdk8
 env:
   global:
     # HCOM OSS Sonatype jira info
@@ -20,17 +17,20 @@ jobs:
     ### JDK11 build
     - stage: "JDK11 Build"
       name: "JDK11 Build and Test"
+      jdk: openjdk11
       if: branch =~ ^((?!-jdk8).)*$ OR tag =~ ^((?!-jdk8).)*$
       script:
         - travis_retry mvn clean install
     ### JDK8 build
     - stage: "JDK8 Build"
       name: "JDK8 Build and Test"
+      jdk: openjdk8
       if: branch =~ ^.*-jdk8$ OR tag =~ ^.*-jdk8$
       script:
         - travis_retry mvn clean install
     - stage: "Site Build and Quality check"
       name: "Publishing site and performing a code quality check"
+      jdk: openjdk8
       if: type NOT IN (pull_request) AND tag IS present AND tag =~ ^((?!-jdk8).)*$
       script: skip
       before_deploy:
@@ -47,6 +47,7 @@ jobs:
     ### JDK11 release
     - stage: "JDK11 Release"
       name: "Releasing artifacts for JDK11"
+      jdk: openjdk11
       if: type NOT IN (pull_request) AND tag IS present AND tag =~ ^((?!-jdk8).)*$
       script: skip
       before_deploy:
@@ -62,6 +63,7 @@ jobs:
     ### JDK8 release
     - stage: "JDK8 Release"
       name: "Releasing artifacts for JDK8"
+      jdk: openjdk8
       if: type NOT IN (pull_request) AND tag IS present AND tag =~ ^.*-jdk8$
       script: skip
       before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,17 +22,20 @@ jobs:
       name: "JDK11 Build and Test"
       if: branch =~ ^((?!-jdk8).)*$ OR tag =~ ^((?!-jdk8).)*$
       script:
+        - jdk_switcher use openjdk11
         - travis_retry mvn clean install
     ### JDK8 build
     - stage: "JDK8 Build"
       name: "JDK8 Build and Test"
       if: branch =~ ^.*-jdk8$ OR tag =~ ^.*-jdk8$
       script:
+        - jdk_switcher use openjdk8
         - travis_retry mvn clean install
     - stage: "Site Build and Quality check"
       name: "Publishing site and performing a code quality check"
       if: type NOT IN (pull_request) AND tag IS present AND tag =~ ^((?!-jdk8).)*$
-      script: skip
+      script:
+        - jdk_switcher use openjdk11
       before_deploy:
         - mvn versions:set -D newVersion=${TRAVIS_TAG}
         - travis_retry mvn install sonar:sonar -Dsonar.projectKey=${sonar_project_key} -Dsonar.organization=${sonar_organization} -Dsonar.host.url=${sonar_host_url} -Dsonar.login=${sonar_token} site:site javadoc:aggregate -P default,site-release
@@ -48,7 +51,8 @@ jobs:
     - stage: "JDK11 Release"
       name: "Releasing artifacts for JDK11"
       if: type NOT IN (pull_request) AND tag IS present AND tag =~ ^((?!-jdk8).)*$
-      script: skip
+      script:
+        - jdk_switcher use openjdk11
       before_deploy:
         - openssl aes-256-cbc -K $encrypted_bbb0f94c13c1_key -iv $encrypted_bbb0f94c13c1_iv -in config/travis/private-key.gpg.enc -out config/travis/private-key.gpg -d
         - mvn versions:set -D newVersion=${TRAVIS_TAG}
@@ -62,9 +66,9 @@ jobs:
     ### JDK8 release
     - stage: "JDK8 Release"
       name: "Releasing artifacts for JDK8"
-      jdk: openjdk8
       if: type NOT IN (pull_request) AND tag IS present AND tag =~ ^.*-jdk8$
-      script: skip
+      script:
+        - jdk_switcher use openjdk11
       before_deploy:
         - openssl aes-256-cbc -K $encrypted_bbb0f94c13c1_key -iv $encrypted_bbb0f94c13c1_iv -in config/travis/private-key.gpg.enc -out config/travis/private-key.gpg -d
         - mvn versions:set -D newVersion=${TRAVIS_TAG}

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
         - travis_retry mvn clean install
     - stage: "Site Build and Quality check"
       name: "Publishing site and performing a code quality check"
-      jdk: openjdk8
+      jdk: openjdk11
       if: type NOT IN (pull_request) AND tag IS present AND tag =~ ^((?!-jdk8).)*$
       script: skip
       before_deploy:
@@ -69,7 +69,7 @@ jobs:
       before_deploy:
         - openssl aes-256-cbc -K $encrypted_bbb0f94c13c1_key -iv $encrypted_bbb0f94c13c1_iv -in config/travis/private-key.gpg.enc -out config/travis/private-key.gpg -d
         - mvn versions:set -D newVersion=${TRAVIS_TAG}
-        - mvn install -DskipTests -Dmaven.test.skip=true javadoc:aggregate
+        - mvn install javadoc:aggregate -P default,site-release
       deploy:
         - provider: script
           script: config/travis/deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: java
 cache:
   directories:
     - "~/.m2/repository"
-jdk: openjdk11
+jdk:
+  - openjdk11
+  - oraclejdk8
 env:
   global:
     # HCOM OSS Sonatype jira info
@@ -17,7 +19,14 @@ jobs:
   include:
     - stage: "Build"
       name: "Build and Test"
+      if: branch !=~ ^.*-jdk8$
       script: travis_retry mvn clean install
+    - stage: "JDK8 Build"
+      name: "Build and Test JDK8"
+      if: branch =~ ^.*-jdk8$
+      script:
+        - jdk_switcher use oraclejdk8
+        - travis_retry mvn clean install
     # If is not a PR and a tag is available
     - stage: "Site Build and Quality check"
       name: "Publishing site and performing a code quality check"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 cache:
   directories:
-    - "~/.m2/repository"
+    - $HOME/.m2
 env:
   global:
     # HCOM OSS Sonatype jira info

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: java
 cache:
   directories:
     - "~/.m2/repository"
-jdk:
-  - openjdk11
-  - oraclejdk8
+#jdk:
+#  - openjdk11
+#  - oraclejdk8
 env:
   global:
     # HCOM OSS Sonatype jira info
@@ -25,7 +25,9 @@ jobs:
         - travis_retry mvn clean install
     - stage: "Build"
       name: "Build and Test"
-      script: travis_retry mvn clean install
+      script:
+        - jdk_switcher use openjdk11
+        - travis_retry mvn clean install
     # If is not a PR and a tag is available
     - stage: "Site Build and Quality check"
       name: "Publishing site and performing a code quality check"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,22 +15,22 @@ env:
 install: skip
 jobs:
   include:
+    ### JDK11 build
+    - stage: "JDK11 Build"
+      name: "JDK11 Build and Test"
+      if: branch =~ ^((?!-jdk8).)*$
+      script:
+        - travis_retry mvn clean install
+    ### JDK8 build
     - stage: "JDK8 Build"
-      name: "Build and Test JDK8"
+      name: "JDK8 Build and Test"
       jdk: oraclejdk8
       if: branch =~ ^.*-jdk8$
       script:
-        - jdk_switcher use oraclejdk8
         - travis_retry mvn clean install
-    - stage: "Build"
-      name: "Build and Test"
-      script:
-        - jdk_switcher use openjdk11
-        - travis_retry mvn clean install
-    # If is not a PR and a tag is available
     - stage: "Site Build and Quality check"
       name: "Publishing site and performing a code quality check"
-      if: type NOT IN (pull_request) AND tag IS present
+      if: type NOT IN (pull_request) AND tag IS present AND branch =~ ^((?!-jdk8).)*$
       script: skip
       before_deploy:
         - mvn versions:set -D newVersion=${TRAVIS_TAG}
@@ -43,10 +43,26 @@ jobs:
         keep-history: true
         on:
           tags: true
-    # If is not a PR and a tag is available
-    - stage: "Release"
-      name: "Releasing artifacts"
-      if: type NOT IN (pull_request) AND tag IS present
+    ### JDK11 release
+    - stage: "JDK11 Release"
+      name: "Releasing artifacts for JDK11"
+      if: type NOT IN (pull_request) AND tag IS present AND branch =~ ^((?!-jdk8).)*$
+      script: skip
+      before_deploy:
+        - openssl aes-256-cbc -K $encrypted_bbb0f94c13c1_key -iv $encrypted_bbb0f94c13c1_iv -in config/travis/private-key.gpg.enc -out config/travis/private-key.gpg -d
+        - mvn versions:set -D newVersion=${TRAVIS_TAG}
+        - mvn install -DskipTests -Dmaven.test.skip=true javadoc:aggregate
+      deploy:
+        - provider: script
+          script: config/travis/deploy.sh
+          skip_cleanup: true
+          on:
+            tags: true
+    ### JDK8 release
+    - stage: "JDK8 Release"
+      name: "Releasing artifacts for JDK8"
+      jdk: oraclejdk8
+      if: type NOT IN (pull_request) AND tag IS present AND branch =~ ^.*-jdk8$
       script: skip
       before_deploy:
         - openssl aes-256-cbc -K $encrypted_bbb0f94c13c1_key -iv $encrypted_bbb0f94c13c1_iv -in config/travis/private-key.gpg.enc -out config/travis/private-key.gpg -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ jobs:
     ### JDK11 build
     - stage: "JDK11 Build"
       name: "JDK11 Build and Test"
+      jdk: openjdk11
       if: branch =~ ^((?!-jdk8).)*$
       script:
         - travis_retry mvn clean install
@@ -30,6 +31,7 @@ jobs:
         - travis_retry mvn clean install
     - stage: "Site Build and Quality check"
       name: "Publishing site and performing a code quality check"
+      jdk: openjdk11
       if: type NOT IN (pull_request) AND tag IS present AND branch =~ ^((?!-jdk8).)*$
       script: skip
       before_deploy:
@@ -46,6 +48,7 @@ jobs:
     ### JDK11 release
     - stage: "JDK11 Release"
       name: "Releasing artifacts for JDK11"
+      jdk: openjdk11
       if: type NOT IN (pull_request) AND tag IS present AND branch =~ ^((?!-jdk8).)*$
       script: skip
       before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: java
 cache:
   directories:
     - $HOME/.m2
+jdk:
+  - openjdk11
+  - openjdk8
 env:
   global:
     # HCOM OSS Sonatype jira info
@@ -17,20 +20,17 @@ jobs:
     ### JDK11 build
     - stage: "JDK11 Build"
       name: "JDK11 Build and Test"
-      jdk: openjdk11
       if: branch =~ ^((?!-jdk8).)*$ OR tag =~ ^((?!-jdk8).)*$
       script:
         - travis_retry mvn clean install
     ### JDK8 build
     - stage: "JDK8 Build"
       name: "JDK8 Build and Test"
-      jdk: openjdk8
       if: branch =~ ^.*-jdk8$ OR tag =~ ^.*-jdk8$
       script:
         - travis_retry mvn clean install
     - stage: "Site Build and Quality check"
       name: "Publishing site and performing a code quality check"
-      jdk: openjdk8
       if: type NOT IN (pull_request) AND tag IS present AND tag =~ ^((?!-jdk8).)*$
       script: skip
       before_deploy:
@@ -47,7 +47,6 @@ jobs:
     ### JDK11 release
     - stage: "JDK11 Release"
       name: "Releasing artifacts for JDK11"
-      jdk: openjdk11
       if: type NOT IN (pull_request) AND tag IS present AND tag =~ ^((?!-jdk8).)*$
       script: skip
       before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: java
 cache:
   directories:
     - "~/.m2/repository"
-jdk: openjdk11
 env:
   global:
     # HCOM OSS Sonatype jira info
@@ -19,20 +18,20 @@ jobs:
     - stage: "JDK11 Build"
       name: "JDK11 Build and Test"
       jdk: openjdk11
-      if: branch =~ ^((?!-jdk8).)*$
+      if: branch =~ ^((?!-jdk8).)*$ OR tag =~ ^((?!-jdk8).)*$
       script:
         - travis_retry mvn clean install
     ### JDK8 build
     - stage: "JDK8 Build"
       name: "JDK8 Build and Test"
-      jdk: oraclejdk8
-      if: branch =~ ^.*-jdk8$
+      jdk: openjdk8
+      if: branch =~ ^.*-jdk8$ OR tag =~ ^.*-jdk8$
       script:
         - travis_retry mvn clean install
     - stage: "Site Build and Quality check"
       name: "Publishing site and performing a code quality check"
-      jdk: openjdk11
-      if: type NOT IN (pull_request) AND tag IS present AND branch =~ ^((?!-jdk8).)*$
+      jdk: openjdk8
+      if: type NOT IN (pull_request) AND tag IS present AND tag =~ ^((?!-jdk8).)*$
       script: skip
       before_deploy:
         - mvn versions:set -D newVersion=${TRAVIS_TAG}
@@ -49,7 +48,7 @@ jobs:
     - stage: "JDK11 Release"
       name: "Releasing artifacts for JDK11"
       jdk: openjdk11
-      if: type NOT IN (pull_request) AND tag IS present AND branch =~ ^((?!-jdk8).)*$
+      if: type NOT IN (pull_request) AND tag IS present AND tag =~ ^((?!-jdk8).)*$
       script: skip
       before_deploy:
         - openssl aes-256-cbc -K $encrypted_bbb0f94c13c1_key -iv $encrypted_bbb0f94c13c1_iv -in config/travis/private-key.gpg.enc -out config/travis/private-key.gpg -d
@@ -64,8 +63,8 @@ jobs:
     ### JDK8 release
     - stage: "JDK8 Release"
       name: "Releasing artifacts for JDK8"
-      jdk: oraclejdk8
-      if: type NOT IN (pull_request) AND tag IS present AND branch =~ ^.*-jdk8$
+      jdk: openjdk8
+      if: type NOT IN (pull_request) AND tag IS present AND tag =~ ^.*-jdk8$
       script: skip
       before_deploy:
         - openssl aes-256-cbc -K $encrypted_bbb0f94c13c1_key -iv $encrypted_bbb0f94c13c1_iv -in config/travis/private-key.gpg.enc -out config/travis/private-key.gpg -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ language: java
 cache:
   directories:
     - "~/.m2/repository"
-#jdk:
-#  - openjdk11
-#  - oraclejdk8
+jdk: openjdk11
 env:
   global:
     # HCOM OSS Sonatype jira info
@@ -19,6 +17,7 @@ jobs:
   include:
     - stage: "JDK8 Build"
       name: "Build and Test JDK8"
+      jdk: oraclejdk8
       if: branch =~ ^.*-jdk8$
       script:
         - jdk_switcher use oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,15 @@ env:
 install: skip
 jobs:
   include:
-    - stage: "Build"
-      name: "Build and Test"
-      if: branch !=~ ^.*-jdk8$
-      script: travis_retry mvn clean install
     - stage: "JDK8 Build"
       name: "Build and Test JDK8"
       if: branch =~ ^.*-jdk8$
       script:
         - jdk_switcher use oraclejdk8
         - travis_retry mvn clean install
+    - stage: "Build"
+      name: "Build and Test"
+      script: travis_retry mvn clean install
     # If is not a PR and a tag is available
     - stage: "Site Build and Quality check"
       name: "Publishing site and performing a code quality check"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: java
 cache:
   directories:
     - $HOME/.m2
+jdk:
+  - openjdk11
+  - openjdk8
 env:
   global:
     # HCOM OSS Sonatype jira info
@@ -17,20 +20,17 @@ jobs:
     ### JDK11 build
     - stage: "JDK11 Build"
       name: "JDK11 Build and Test"
-      jdk: openjdk11
       if: branch =~ ^((?!-jdk8).)*$ OR tag =~ ^((?!-jdk8).)*$
       script:
         - travis_retry mvn clean install
     ### JDK8 build
     - stage: "JDK8 Build"
       name: "JDK8 Build and Test"
-      jdk: openjdk8
       if: branch =~ ^.*-jdk8$ OR tag =~ ^.*-jdk8$
       script:
         - travis_retry mvn clean install
     - stage: "Site Build and Quality check"
       name: "Publishing site and performing a code quality check"
-      jdk: openjdk8
       if: type NOT IN (pull_request) AND tag IS present AND tag =~ ^((?!-jdk8).)*$
       script: skip
       before_deploy:
@@ -47,7 +47,6 @@ jobs:
     ### JDK11 release
     - stage: "JDK11 Release"
       name: "Releasing artifacts for JDK11"
-      jdk: openjdk11
       if: type NOT IN (pull_request) AND tag IS present AND tag =~ ^((?!-jdk8).)*$
       script: skip
       before_deploy:
@@ -63,7 +62,6 @@ jobs:
     ### JDK8 release
     - stage: "JDK8 Release"
       name: "Releasing artifacts for JDK8"
-      jdk: openjdk8
       if: type NOT IN (pull_request) AND tag IS present AND tag =~ ^.*-jdk8$
       script: skip
       before_deploy:

--- a/CHANGELOG-JDK8.md
+++ b/CHANGELOG-JDK8.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+### [1.6.1.1-jdk8] 2019.11.27
+#### Changed
+* Aligned `jdk8` version to the `jdk11` one
+
 ### [1.1.27] 2019.11.22
 #### Changed
 * Removed warning leg message in case the constructor parameter names are not available in the compiled code.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -28,3 +28,6 @@ Please describe the tests that you ran to verify your changes. Please also note 
 - [ ] Any dependent changes have been merged and published in downstream modules
 - [ ] My changes have no bad impacts on performances
 - [ ] Any implemented change has been added in the [CHANGELOG.md](./CHANGELOG.md) file 
+- [ ] Any implemented change has been added in the [CHANGELOG-JDK8.md](./CHANGELOG-JDK8.md) file 
+- [ ] My changes have been applied on a separate branch too with compatibility with Java 8. Follow this (instructions)[https://github.com/HotelsDotCom/bull/blob/master/RELEASE.md#3-prepare-the-jdk8-release] for help. 
+- [ ] The maven version has been increased. 

--- a/README.md
+++ b/README.md
@@ -814,6 +814,10 @@ The application's logo has been designed by: Rob Light.
  - DZone: [How to Transform Any Type of Java Bean With BULL](https://dzone.com/articles/how-to-transform-any-type-of-java-bean-with-one-li)
  - InfoQ: [How Expedia Is Getting Rid of Java Bean Transformers](https://www.infoq.com/articles/expedia-rid-of-bean-transformers/) [[EN](https://www.infoq.com/articles/expedia-rid-of-bean-transformers/)] [[PT-BR](https://www.infoq.com/br/articles/expedia-rid-of-bean-transformers/)]
 
+## Release
+
+All the instructions for releasing a new version are available at: [RELEASES.md](RELEASE.md)
+
 ## Legal
 
 This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,190 +10,179 @@ Make the following checks before performing a release:
    * Do all unit tests pass?
    * Do all examples work?
    * Does documentation build?
-
+   * Have the new features been applied on a separate branch with compatibility with `jdk8?
 
 #### 2. Update VERSION and CHANGELOG
 
-##### Increment the version number.
+#### Increment the version number.
 
-The version number is in the [`VERSION`](VERSION) file. This is picked up by the documentation build process.
+The application is released with the compatibility for both: `jdk11` and `jdk8`, the latest version number are:
+in the [CHANGELOG](CHANGELOG.md) file for `jdk11` and [CHANGELOG-JDK](CHANGELOG-JDK8.md) file for `jdk8`. 
 
-It consists of two lines. The first carries the version number. The structure is: *major* **.** *minor* **.** *revision*.
-The *revision* part is *not included* if it is zero '0' (just after a *major* or *minor* increment).
+The version number structure is: *major* **.** *minor* **.** *revision*.
    * *major* = significant incompatible change (e.g. partial or whole rewrite).
    * *minor* = some new functionality or changes that are mostly/wholly backward compatible.
    * *revision* = very minor changes, e.g. bugfixes.
+   
+For `jdk8` only, the version number is the same as the `jdk11` one, with the suffix: `-jdk8`.
 
-The 2nd line carries the state - whether this is the "latest" code in the master branch, or whether it is a "release".
-Leave this as "latest" for the moment.
+e.g. if the new release version would be `1.8.0` then the `jdk8` correspondent one is: `1.8.0-jdk8
 
+#### Update the change log
 
-##### Update the change log
+The changes, that are going to be released, needs to be specified in the `CHANGELOG` file.
+Ensure it mentions any noteworthy changes since the previous release.
 
-The is in the [`CHANGELOG.md`](CHANGELOG.md) file. Ensure it mentions any noteworthy changes since the previous release.
+Make the following check before performing a release:
+* Add the version is going to be released
+* Place the release date next to the version number (the format is: `yyyy.mm.dd`)
+* Specify under the `### Added` label everything that has been introduced by the new version 
+* Specify under the `### Changed` label everything that has been changed in the new version 
+* Specify under the `### Removed` label everything that has been removed in the new version 
 
+the same changes must be reported in [CHANGELOG-JDK](CHANGELOG-JDK8.md)
 
-#### 3. Create release branch
+#### 3. Prepare the jdk8 release
 
-Create the branch, naming it after the release version number (just the number).
+All the changes implemented needs to be reported to the `jdk8` compatible version.
+The BULL code for the `jdk8` is slightly different so all the changes needs to be reported on the other version starting
+from it's latest release tag.
+The first thing to do is to create a branch (that would have the same name as the `jdk11` one plus the suffix: `-jd8`)
+starting from the latest `jdk8` release tag:
 
-In the branch, now modify (and commit) the VERSION file, changing "latest" to "release".
+~~~
+$ git checkout -b [branch name]-jdk8 [latest jdk8 release tag] 
+~~~
 
+e.g. if the latest `jdk8` release tag is: `1.7.0-jdk8` and the new feature branch is: `feature/my-new-feature`
+the command to perform is: 
 
-#### 4. Create a new release on GitHub based on the new branch
+~~~
+$ git checkout -b feature/my-new-feature-jdk8 1.7.0-jdk8 
+~~~
 
-Put a shorter summary of the new changelog items into the release notes. Make the tag name the version number
-- the same as the branch name.
+**IMPORTANT:** In the new branch, apply only the changes introduced comparing the code with the `jdk11` branch.
 
-
-#### 5. Update documentation builds on gh-pages
-
-Run the documentation build process to build documentation for:
-
-* This new "release" branch ("new")
-* *master* branch ("latest")
-
-Note that these are slightly different (because of the 2nd line in the `VERSION` file)
-
-Checkout the [gh-pages](https://github.com/bbc/dial-discovery-ios/tree/gh-pages) branch and make the following commits:
-
-* replace the contents of [`docs/latest`](https://github.com/bbc/dial-discovery-ios/tree/gh-pages/docs/latest)
-  with the documentation build for the "latest" state of master.
-
-* put into `docs/XXXX` the documentation build for the "new" release branch, where XXXX is the version number
-
-Then push the commits up to GitHub.
-
-#### 6. Release new CocoaPod version
-
-The process originally followed to register and setup first time was [this one](https://code.tutsplus.com/tutorials/creating-your-first-cocoapod--cms-24332). You need to be registered with CocoaPods Trunk
-repository to be able to publish a pod. Instructions to register with CocoaPods Trunk are available [here](https://guides.cocoapods.org/making/getting-setup-with-trunk.html)
-
-
-For subsequent releases, increment the version number in the PodSpec file and push the new pod version .
-
-    $ pod trunk push dial-discovery-ios.podspec
-
-
-- - - - -
+when completed, commit your code and verify that the [Travis build](https://travis-ci.org/HotelsDotCom/bull/builds) is green. 
 
 ## Example of release process sequence
 
-This example assumes your local repository is a clone and the working copy is currently at the head of the master branch, and that this is all
-synced with GitHub. The following steps will do a release "X.Y.Z"
+The following examples assume that your local repository is:
 
-    $ git status
-    On branch master
-    Your branch is up-to-date with 'origin/master'.
-    nothing to commit, working directory clean
+* a clone and the working copy is currently at the head of the master branch
+* is all synced with GitHub
+* the Pull Request has been approved and merged on master
 
-### 1. Run checks
+### JDK8
 
-Run unit tests:
+The following steps will do a release "`X.Y.Z-jdk8`"
 
-    $ xcodebuild test -workspace Example/dial-discovery-ios.xcworkspace -scheme dial-discovery-ios-Example -sdk iphonesimulator9.3 ONLY_ACTIVE_ARCH=NO | xcpretty
-    $ pod lib lint
+~~~
+$ git status
+On branch master
+Your branch is up-to-date with 'origin/master'.
+nothing to commit, working directory clean
+~~~
 
+#### 1. Create a branch from the latest JDK8 release tag
 
-Also check the documentation builds:
+Assuming that:
 
-    $ cd docs
-    $ jazzy --config jazzy.yaml
+* the latest release for `jdk8` was: `A.B.C-jdk8` 
+* your new feature branch is: `feature/my-new-feature`
+* the new release version is: `X.Y.Z-jdk8`
 
-... and manually review areas where it will have changed
+the release branch would be: `release/my-new-feature-jdk8`
 
-And run all examples and check they work!
+~~~
+$ git checkout -b release/my-new-feature-jdk8 A.B.C-jdk8 
+~~~
 
+#### 2. Apply the changes to the new branch
 
+Apply all the changes you implemented to this branch. 
 
-### 2. Update VERSION and CHANGELOG
+#### 3. Change the maven version
 
-Update the version number in `master`, e.g. using `vi`:
+The maven version is now set with the latest released, but you need to change it with the new one you are going to release:
 
-    $ vi VERSION
-        .. change version number line only ..
-    $ vi CHANGELOG.md
-        .. update change log  ..
-    $ git add VERSION
-    $ git add CHANGELOG.md
-    $ git commit -m "Version number increment and Changelog update ready for release"
+~~~
+$ mvn versions:set -D newVersion=X.Y.Z-jdk8
+~~~
 
-And push to GitHub:
+Commit all the changes.
 
-    $ git push origin master
+#### 4. Create a new tag for the release version
 
-### 3. Create release branch
+Once you will have created the tag, and pushed it to the remote repo, an automatic release will be performed by Travis.
 
-Create new branch (locally)
+~~~
+$ git tag -a X.Y.Z-jdk8 -m "my version X.Y.Z-jdk8"
+$ git push origin --tags
+~~~
 
-    $ git checkout -b 'X.Y.Z'
+#### 5. Remove the no longer needed branch
 
-Update VERSION to mark as "release" within the branch
+If the release went successfully, you can now delete the branch:
 
-    $ vi VERSION
-       .. change "latest" to "release"
-    $ git add VERSION
-    $ git commit -m "Version marked as release."
+~~~
+$ git branch -D release/my-new-feature-jdk8
+$ git push <remote_name> --delete release/my-new-feature-jdk8
+~~~
 
-Push branch up to github (and set local repository to track the upstream branch on origin):
+**IMPORTANT:** In case something goes wrong, do not leave ghost tags or tags not related to a successful release.
 
-    $ git push -u origin 'X.Y.Z'
+### JDK11
 
+The following steps will do a release "`X.Y.Z`"
 
-### 4. Create a new release on GitHub based on the new branch
+~~~
+$ git status
+On branch master
+Your branch is up-to-date with 'origin/master'.
+nothing to commit, working directory clean
+~~~
 
-Now use the [new release](https://github.com/bbc/dial-discovery-ios/releases/new) function on GitHub's web interface to
-mark the branch 'X.Y.Z' as a new release.
+#### 1. Create a branch from the master branch
 
-### 5. Update documentation builds on gh-pages
+Assuming that:
 
-First, build and copy the documentation for the release and stash it somewhere temporarily.
+* the latest release for `jdk11` was: `A.B.C` 
+* your new feature branch is: `feature/my-new-feature`
+* the new release version is: `X.Y.Z`
 
-    $ git status
-    On branch X.Y.Z
-    Your branch is up-to-date with 'origin/master'.
-    nothing to commit, working directory clean
+the release branch would be: `release/my-new-feature`
 
-    $ cd docs
-    $ jazzy --config jazzy.yaml
-    $ cp -R build/ /tmp/X.Y.Z
+~~~
+$ git checkout -b release/my-new-feature
+~~~
 
-Now switch back to master and do the same for the latest state of master:
+#### 2. Change the maven version
 
-    $ git checkout master
-    $ jazzy --config jazzy.yaml
-    $ cp -R build/ tmp/latest
-    $ cd ..
+The maven version is now set with the latest released, but you need to change it with the new one you are going to release:
 
-Now switch to gh-pages and ensure it is synced with GitHub:
+~~~
+$ mvn versions:set -D newVersion=X.Y.Z
+~~~
 
-    $ git checkout gh-pages
-    $ git pull origin gh-pages
+Commit all the changes.
 
-And put the new documentation builds in place:
+#### 3. Create a new tag for the release version
 
-    $ cp -R /tmp/X.Y.Z docs/X.Y.Z
-    $ git add docs/X.Y.Z
+Once you will have created the tag, and pushed it to the remote repo, an automatic release will be performed by Travis.
 
-    $ git rm docs/latest
-    $ cp -R /tmp/latest docs/latest
-    $ git add docs/latest
+~~~
+$ git tag -a X.Y.Z -m "my version X.Y.Z"
+$ git push origin --tags
+~~~
 
-    $ git commit -m "Updated docs for new release and latest changes in master"
+#### 4. Remove the no longer needed branch
 
-At this point the `docs` dir should contain:
+If the release went successfully, you can now delete the branch:
 
-* a subdir `X.Y.Z` (named after the release version) containing the HTML documentation for
-  that version. `index.html` should describe the release version as being *"X.Y.Z-release"*
+~~~
+$ git branch -D release/my-new-feature
+$ git push <remote_name> --delete release/my-new-feature-jdk8
+~~~
 
-* a subdir `latest` containing the HTML documentation built from *master*. `index.html` should describe the
-  release version as being *"X.Y.Z-latest"*
-
-Push to GitHub:
-
-    $ git push origin gh-pages
-
-Upload to CocoaPods Trunk:
-
-    $ git checkout <<release-branch>>
-    $ pod trunk push dial-discovery-ios.podspec
+**IMPORTANT:** In case something goes wrong, do not leave ghost tags or tags not related to a successful release.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,7 +17,7 @@ Make the following checks before performing a release:
 #### Increment the version number.
 
 The application is released with the compatibility for both: `jdk11` and `jdk8`, the latest version number are:
-in the [CHANGELOG](CHANGELOG.md) file for `jdk11` and [CHANGELOG-JDK](CHANGELOG-JDK8.md) file for `jdk8`. 
+in the [CHANGELOG.md](CHANGELOG.md) file for `jdk11` and [CHANGELOG-JDK8.md](CHANGELOG-JDK8.md) file for `jdk8`. 
 
 The version number structure is: *major* **.** *minor* **.** *revision*.
    * *major* = significant incompatible change (e.g. partial or whole rewrite).
@@ -26,7 +26,7 @@ The version number structure is: *major* **.** *minor* **.** *revision*.
    
 For `jdk8` only, the version number is the same as the `jdk11` one, with the suffix: `-jdk8`.
 
-e.g. if the new release version would be `1.8.0` then the `jdk8` correspondent one is: `1.8.0-jdk8`
+e.g. if the new release version would be `X.Y.Z` then the `jdk8` correspondent one is: `X.Y.Z-jdk8`
 
 #### Update the change log
 
@@ -40,13 +40,15 @@ Make the following check before performing a release:
 * Specify under the `### Changed` label everything that has been changed in the new version 
 * Specify under the `### Removed` label everything that has been removed in the new version 
 
-the same changes must be reported in [CHANGELOG-JDK](CHANGELOG-JDK8.md)
+the same changes must be reported in [CHANGELOG-JDK8.md](CHANGELOG-JDK8.md)
 
 #### 3. Prepare the jdk8 release
 
-All the changes implemented needs to be reported to the `jdk8` compatible version.
+All the changes implemented needs to be reported to a `jdk8` compatible version.
+
 The BULL code for the `jdk8` is slightly different so all the changes needs to be reported on the other version starting
 from it's latest release tag.
+
 The first thing to do is to create a branch (that would have the same name as the `jdk11` one plus the suffix: `-jd8`)
 starting from the latest `jdk8` release tag:
 
@@ -72,12 +74,14 @@ The following examples assume that your local repository is:
 * is all synced with GitHub
 * the Pull Request has been approved and merged on master
 
-* [JDK8](https://github.com/HotelsDotCom/bull/blob/master/RELEASE.md#jdk8)
-* [JDK11](https://github.com/HotelsDotCom/bull/blob/master/RELEASE.md#jdk11)
+The guide explains how to do a release both the `jdk11` and `jdk8` compatible:
+
+* [JDK8 Release](https://github.com/HotelsDotCom/bull/blob/master/RELEASE.md#jdk8)
+* [JDK11 Release](https://github.com/HotelsDotCom/bull/blob/master/RELEASE.md#jdk11)
 
 **IMPORTANT:** In case something goes wrong, do not leave ghost tags or tags not related to a successful release.
 
-### JDK8
+### JDK8 Release
 
 The following steps will do a release "`X.Y.Z-jdk8`"
 
@@ -134,7 +138,7 @@ $ git branch -D release/my-new-feature-jdk8
 $ git push <remote_name> --delete release/my-new-feature-jdk8
 ~~~
 
-### JDK11
+### JDK11 Release
 
 The following steps will do a release "`X.Y.Z`"
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -76,8 +76,8 @@ The following examples assume that your local repository is:
 
 The guide explains how to do a release both the `jdk11` and `jdk8` compatible:
 
-* [JDK8 Release](https://github.com/HotelsDotCom/bull/blob/master/RELEASE.md#jdk8)
-* [JDK11 Release](https://github.com/HotelsDotCom/bull/blob/master/RELEASE.md#jdk11)
+* [JDK8 Release](https://github.com/HotelsDotCom/bull/blob/master/RELEASE.md#jdk8-release)
+* [JDK11 Release](https://github.com/HotelsDotCom/bull/blob/master/RELEASE.md#jdk11-release)
 
 **IMPORTANT:** In case something goes wrong, do not leave ghost tags or tags not related to a successful release.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,199 @@
+# Release process for BULL
+
+## Explanation of the process sequence
+
+Assumption that the current state of *master* will constitute the release...
+
+#### 1. Pre-release checks
+
+Make the following checks before performing a release:
+   * Do all unit tests pass?
+   * Do all examples work?
+   * Does documentation build?
+
+
+#### 2. Update VERSION and CHANGELOG
+
+##### Increment the version number.
+
+The version number is in the [`VERSION`](VERSION) file. This is picked up by the documentation build process.
+
+It consists of two lines. The first carries the version number. The structure is: *major* **.** *minor* **.** *revision*.
+The *revision* part is *not included* if it is zero '0' (just after a *major* or *minor* increment).
+   * *major* = significant incompatible change (e.g. partial or whole rewrite).
+   * *minor* = some new functionality or changes that are mostly/wholly backward compatible.
+   * *revision* = very minor changes, e.g. bugfixes.
+
+The 2nd line carries the state - whether this is the "latest" code in the master branch, or whether it is a "release".
+Leave this as "latest" for the moment.
+
+
+##### Update the change log
+
+The is in the [`CHANGELOG.md`](CHANGELOG.md) file. Ensure it mentions any noteworthy changes since the previous release.
+
+
+#### 3. Create release branch
+
+Create the branch, naming it after the release version number (just the number).
+
+In the branch, now modify (and commit) the VERSION file, changing "latest" to "release".
+
+
+#### 4. Create a new release on GitHub based on the new branch
+
+Put a shorter summary of the new changelog items into the release notes. Make the tag name the version number
+- the same as the branch name.
+
+
+#### 5. Update documentation builds on gh-pages
+
+Run the documentation build process to build documentation for:
+
+* This new "release" branch ("new")
+* *master* branch ("latest")
+
+Note that these are slightly different (because of the 2nd line in the `VERSION` file)
+
+Checkout the [gh-pages](https://github.com/bbc/dial-discovery-ios/tree/gh-pages) branch and make the following commits:
+
+* replace the contents of [`docs/latest`](https://github.com/bbc/dial-discovery-ios/tree/gh-pages/docs/latest)
+  with the documentation build for the "latest" state of master.
+
+* put into `docs/XXXX` the documentation build for the "new" release branch, where XXXX is the version number
+
+Then push the commits up to GitHub.
+
+#### 6. Release new CocoaPod version
+
+The process originally followed to register and setup first time was [this one](https://code.tutsplus.com/tutorials/creating-your-first-cocoapod--cms-24332). You need to be registered with CocoaPods Trunk
+repository to be able to publish a pod. Instructions to register with CocoaPods Trunk are available [here](https://guides.cocoapods.org/making/getting-setup-with-trunk.html)
+
+
+For subsequent releases, increment the version number in the PodSpec file and push the new pod version .
+
+    $ pod trunk push dial-discovery-ios.podspec
+
+
+- - - - -
+
+## Example of release process sequence
+
+This example assumes your local repository is a clone and the working copy is currently at the head of the master branch, and that this is all
+synced with GitHub. The following steps will do a release "X.Y.Z"
+
+    $ git status
+    On branch master
+    Your branch is up-to-date with 'origin/master'.
+    nothing to commit, working directory clean
+
+### 1. Run checks
+
+Run unit tests:
+
+    $ xcodebuild test -workspace Example/dial-discovery-ios.xcworkspace -scheme dial-discovery-ios-Example -sdk iphonesimulator9.3 ONLY_ACTIVE_ARCH=NO | xcpretty
+    $ pod lib lint
+
+
+Also check the documentation builds:
+
+    $ cd docs
+    $ jazzy --config jazzy.yaml
+
+... and manually review areas where it will have changed
+
+And run all examples and check they work!
+
+
+
+### 2. Update VERSION and CHANGELOG
+
+Update the version number in `master`, e.g. using `vi`:
+
+    $ vi VERSION
+        .. change version number line only ..
+    $ vi CHANGELOG.md
+        .. update change log  ..
+    $ git add VERSION
+    $ git add CHANGELOG.md
+    $ git commit -m "Version number increment and Changelog update ready for release"
+
+And push to GitHub:
+
+    $ git push origin master
+
+### 3. Create release branch
+
+Create new branch (locally)
+
+    $ git checkout -b 'X.Y.Z'
+
+Update VERSION to mark as "release" within the branch
+
+    $ vi VERSION
+       .. change "latest" to "release"
+    $ git add VERSION
+    $ git commit -m "Version marked as release."
+
+Push branch up to github (and set local repository to track the upstream branch on origin):
+
+    $ git push -u origin 'X.Y.Z'
+
+
+### 4. Create a new release on GitHub based on the new branch
+
+Now use the [new release](https://github.com/bbc/dial-discovery-ios/releases/new) function on GitHub's web interface to
+mark the branch 'X.Y.Z' as a new release.
+
+### 5. Update documentation builds on gh-pages
+
+First, build and copy the documentation for the release and stash it somewhere temporarily.
+
+    $ git status
+    On branch X.Y.Z
+    Your branch is up-to-date with 'origin/master'.
+    nothing to commit, working directory clean
+
+    $ cd docs
+    $ jazzy --config jazzy.yaml
+    $ cp -R build/ /tmp/X.Y.Z
+
+Now switch back to master and do the same for the latest state of master:
+
+    $ git checkout master
+    $ jazzy --config jazzy.yaml
+    $ cp -R build/ tmp/latest
+    $ cd ..
+
+Now switch to gh-pages and ensure it is synced with GitHub:
+
+    $ git checkout gh-pages
+    $ git pull origin gh-pages
+
+And put the new documentation builds in place:
+
+    $ cp -R /tmp/X.Y.Z docs/X.Y.Z
+    $ git add docs/X.Y.Z
+
+    $ git rm docs/latest
+    $ cp -R /tmp/latest docs/latest
+    $ git add docs/latest
+
+    $ git commit -m "Updated docs for new release and latest changes in master"
+
+At this point the `docs` dir should contain:
+
+* a subdir `X.Y.Z` (named after the release version) containing the HTML documentation for
+  that version. `index.html` should describe the release version as being *"X.Y.Z-release"*
+
+* a subdir `latest` containing the HTML documentation built from *master*. `index.html` should describe the
+  release version as being *"X.Y.Z-latest"*
+
+Push to GitHub:
+
+    $ git push origin gh-pages
+
+Upload to CocoaPods Trunk:
+
+    $ git checkout <<release-branch>>
+    $ pod trunk push dial-discovery-ios.podspec

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -104,6 +104,7 @@ the release branch would be: `release/my-new-feature-jdk8`
 
 ~~~
 $ git checkout -b release/my-new-feature-jdk8 A.B.C-jdk8 
+$ git push --set-upstream origin release/my-new-feature-jdk8 
 ~~~
 
 #### 2. Apply the changes to the new branch

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-# Release process for BULL
+# Release process
 
 ## Explanation of the process sequence
 
@@ -10,7 +10,7 @@ Make the following checks before performing a release:
    * Do all unit tests pass?
    * Do all examples work?
    * Does documentation build?
-   * Have the new features been applied on a separate branch with compatibility with `jdk8?
+   * Have the new features been applied on a separate branch with compatibility with `jdk8`?
 
 #### 2. Update VERSION and CHANGELOG
 
@@ -26,7 +26,7 @@ The version number structure is: *major* **.** *minor* **.** *revision*.
    
 For `jdk8` only, the version number is the same as the `jdk11` one, with the suffix: `-jdk8`.
 
-e.g. if the new release version would be `1.8.0` then the `jdk8` correspondent one is: `1.8.0-jdk8
+e.g. if the new release version would be `1.8.0` then the `jdk8` correspondent one is: `1.8.0-jdk8`
 
 #### Update the change log
 
@@ -62,8 +62,7 @@ $ git checkout -b feature/my-new-feature-jdk8 1.7.0-jdk8
 ~~~
 
 **IMPORTANT:** In the new branch, apply only the changes introduced comparing the code with the `jdk11` branch.
-
-when completed, commit your code and verify that the [Travis build](https://travis-ci.org/HotelsDotCom/bull/builds) is green. 
+When completed, commit your code and verify that the [Travis build](https://travis-ci.org/HotelsDotCom/bull/builds) is green. 
 
 ## Example of release process sequence
 
@@ -72,6 +71,11 @@ The following examples assume that your local repository is:
 * a clone and the working copy is currently at the head of the master branch
 * is all synced with GitHub
 * the Pull Request has been approved and merged on master
+
+* [JDK8](https://github.com/HotelsDotCom/bull/blob/master/RELEASE.md#jdk8)
+* [JDK11](https://github.com/HotelsDotCom/bull/blob/master/RELEASE.md#jdk11)
+
+**IMPORTANT:** In case something goes wrong, do not leave ghost tags or tags not related to a successful release.
 
 ### JDK8
 
@@ -130,8 +134,6 @@ $ git branch -D release/my-new-feature-jdk8
 $ git push <remote_name> --delete release/my-new-feature-jdk8
 ~~~
 
-**IMPORTANT:** In case something goes wrong, do not leave ghost tags or tags not related to a successful release.
-
 ### JDK11
 
 The following steps will do a release "`X.Y.Z`"
@@ -184,5 +186,3 @@ If the release went successfully, you can now delete the branch:
 $ git branch -D release/my-new-feature
 $ git push <remote_name> --delete release/my-new-feature-jdk8
 ~~~
-
-**IMPORTANT:** In case something goes wrong, do not leave ghost tags or tags not related to a successful release.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -109,7 +109,7 @@ $ git push --set-upstream origin release/my-new-feature-jdk8
 
 #### 2. Apply the changes to the new branch
 
-Apply all the changes you implemented to this branch. 
+Apply all the changes you implemented to this branch.
 
 #### 3. Change the maven version
 
@@ -119,7 +119,7 @@ The maven version is now set with the latest released, but you need to change it
 $ mvn versions:set -D newVersion=X.Y.Z-jdk8
 ~~~
 
-Commit all the changes.
+Commit all the changes and verify that the [Travis build](https://travis-ci.org/HotelsDotCom/bull/builds) is green.
 
 #### 4. Create a new tag for the release version
 
@@ -172,7 +172,7 @@ The maven version is now set with the latest released, but you need to change it
 $ mvn versions:set -D newVersion=X.Y.Z
 ~~~
 
-Commit all the changes.
+Commit all the changes and verify that the [Travis build](https://travis-ci.org/HotelsDotCom/bull/builds) is green.
 
 #### 3. Create a new tag for the release version
 


### PR DESCRIPTION
## Description

This implementation is related to the issue: #105 

## How Has This Been Tested?

- [X] A branch with the suffix `-jdk8` is build with `jdk8`
- [X] A branch without the suffix `-jdk8` is build with `jdk11`
- [X] Once a tag with the suffix `-jdk8` is created a `jdk8` compatible version is automatically released by Travis

## Checklist:

- [X] The branch follows the best practices naming convention:
     - Use grouping tokens (words) at the beginning of your branch names.
        * `feature`: Feature I'm adding or expanding
        * `bug`: Bug fix or experiment
        * `wip`: Work in progress; stuff I know won't be finished soon
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] My changes have no bad impacts on performances
- [X] Any implemented change has been added in the [CHANGELOG.md](./CHANGELOG.md) file 
