### PR TITLE
BeanTransformer method: setDefaultValueSetEnabled refactoring

### DIFF
--- a/bull-bean-transformer/src/main/java/com/hotels/beans/transformer/AbstractBeanTransformer.java
+++ b/bull-bean-transformer/src/main/java/com/hotels/beans/transformer/AbstractBeanTransformer.java
@@ -66,6 +66,15 @@ abstract class AbstractBeanTransformer extends AbstractTransformer<BeanTransform
      * {@inheritDoc}
      */
     @Override
+    public BeanTransformer setDefaultValueForMissingPrimitiveField(final boolean useDefaultValue) {
+        settings.setDefaultValueSetEnabled(useDefaultValue);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public final BeanTransformer setFlatFieldNameTransformation(final boolean useFlatTransformation) {
         settings.setFlatFieldNameTransformation(useFlatTransformation);
         return this;
@@ -88,7 +97,7 @@ abstract class AbstractBeanTransformer extends AbstractTransformer<BeanTransform
      */
     @Override
     public BeanTransformer setDefaultValueSetEnabled(final boolean defaultValueSetEnabled) {
-        settings.setDefaultValueSetEnabled(defaultValueSetEnabled);
+        setDefaultValueForMissingPrimitiveField(defaultValueSetEnabled);
         return this;
     }
 

--- a/bull-bean-transformer/src/main/java/com/hotels/beans/transformer/BeanTransformer.java
+++ b/bull-bean-transformer/src/main/java/com/hotels/beans/transformer/BeanTransformer.java
@@ -54,6 +54,13 @@ public interface BeanTransformer extends Transformer<BeanTransformer> {
     BeanTransformer setDefaultValueForMissingField(boolean useDefaultValue);
 
     /**
+     * It allows to enable/disable the set of the default value for primitive types in case they are null.
+     * @param useDefaultValue if true the default value for the primitive type is set. By default it's true.
+     * @return the {@link BeanTransformer} instance
+     */
+    BeanTransformer setDefaultValueForMissingPrimitiveField(boolean useDefaultValue);
+
+    /**
      * It allows to configure the transformer in order to apply a transformation function on all fields matching the given name without keeping in consideration their full path.
      * If set to true the default value is set, if false if it raises a: {@link com.hotels.transformer.error.MissingFieldException} in case of missing fields.
      * @param useFlatTransformation indicates if the transformer function has to be performed on all fields matching the given name without keeping in consideration their full
@@ -85,7 +92,9 @@ public interface BeanTransformer extends Transformer<BeanTransformer> {
      * It allows to enable/disable the set of the default value for primitive types in case they are null.
      * @param defaultValueSetEnabled if true the default value for the primitive type is set. By default it's true.
      * @return the {@link BeanTransformer} instance
+     * @deprecated use {@link #setDefaultValueForMissingPrimitiveField(boolean) setDefaultValueForMissingPrimitiveField} instead.
      */
+    @Deprecated(since = "1.7.1", forRemoval = true)
     BeanTransformer setDefaultValueSetEnabled(boolean defaultValueSetEnabled);
 
     /**

--- a/bull-bean-transformer/src/test/java/com/hotels/beans/BeanUtilsTest.java
+++ b/bull-bean-transformer/src/test/java/com/hotels/beans/BeanUtilsTest.java
@@ -16,8 +16,8 @@
 
 package com.hotels.beans;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs;

--- a/bull-bean-transformer/src/test/java/com/hotels/beans/transformer/BuilderObjectTransformationTest.java
+++ b/bull-bean-transformer/src/test/java/com/hotels/beans/transformer/BuilderObjectTransformationTest.java
@@ -16,7 +16,7 @@
 
 package com.hotels.beans.transformer;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs;
 

--- a/bull-bean-transformer/src/test/java/com/hotels/beans/transformer/ImmutableObjectTransformationTest.java
+++ b/bull-bean-transformer/src/test/java/com/hotels/beans/transformer/ImmutableObjectTransformationTest.java
@@ -18,12 +18,12 @@ package com.hotels.beans.transformer;
 
 import static java.lang.String.format;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;

--- a/bull-bean-transformer/src/test/java/com/hotels/beans/transformer/MixedObjectTransformationTest.java
+++ b/bull-bean-transformer/src/test/java/com/hotels/beans/transformer/MixedObjectTransformationTest.java
@@ -16,11 +16,11 @@
 
 package com.hotels.beans.transformer;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 
 import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs;
 

--- a/bull-bean-transformer/src/test/java/com/hotels/beans/transformer/MutableObjectTransformationTest.java
+++ b/bull-bean-transformer/src/test/java/com/hotels/beans/transformer/MutableObjectTransformationTest.java
@@ -18,12 +18,12 @@ package com.hotels.beans.transformer;
 
 import static java.lang.Integer.parseInt;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -185,6 +185,24 @@ public class MutableObjectTransformationTest extends AbstractBeanTransformerTest
      */
     @Test
     public void testTransformerDoesNotSetsTheDefaultValueForPrimitiveTypeField() {
+        //GIVEN
+        FromFooSimpleNoGetters fromFooSimpleNoGetters = new FromFooSimpleNoGetters(NAME, null, ACTIVE);
+        underTest.setDefaultValueForMissingPrimitiveField(false);
+
+        //WHEN
+        MutableToFooSimpleNoSetters actual = underTest.transform(fromFooSimpleNoGetters, MutableToFooSimpleNoSetters.class);
+
+        //THEN
+        assertThat(actual, sameBeanAs(fromFooSimpleNoGetters));
+        underTest.setDefaultValueForMissingPrimitiveField(true);
+    }
+
+    /**
+     * Test that the transformer does not sets the default value for primitive type field
+     * in case it's disabled using the deprecated method.
+     */
+    @Test
+    public void testTransformerDoesNotSetsTheDefaultValueForPrimitiveTypeFieldUsingDeprecatedMethod() {
         //GIVEN
         FromFooSimpleNoGetters fromFooSimpleNoGetters = new FromFooSimpleNoGetters(NAME, null, ACTIVE);
         underTest.setDefaultValueSetEnabled(false);

--- a/bull-map-transformer/src/test/java/com/hotels/map/transformer/MapTransformerTest.java
+++ b/bull-map-transformer/src/test/java/com/hotels/map/transformer/MapTransformerTest.java
@@ -20,13 +20,13 @@ import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.ZERO;
 import static java.util.Collections.singletonList;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.isIn;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.MockitoAnnotations.initMocks;
 


### PR DESCRIPTION
- Deprecates the method: `setDefaultValueSetEnabled` and replaces it with: `setDefaultValueForMissingPrimitiveField`
- Replaces usage of `Assert.assertThat` (that is deprecated) with `MatcherAssert.assertThat`