### PR TITLE
Replaces the Mockito deprecated method `initMocks` with the new one: …

### DIFF
--- a/bull-bean-transformer/src/test/java/com/hotels/beans/BeanUtilsTest.java
+++ b/bull-bean-transformer/src/test/java/com/hotels/beans/BeanUtilsTest.java
@@ -17,7 +17,7 @@
 package com.hotels.beans;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -57,7 +57,7 @@ public class BeanUtilsTest {
      */
     @BeforeClass
     public void beforeClass() {
-        initMocks(this);
+        openMocks(this);
     }
 
     /**

--- a/bull-bean-transformer/src/test/java/com/hotels/beans/performance/PerformanceTest.java
+++ b/bull-bean-transformer/src/test/java/com/hotels/beans/performance/PerformanceTest.java
@@ -22,7 +22,7 @@ import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -95,7 +95,7 @@ public class PerformanceTest {
     @BeforeClass
     public void beforeClass() {
         initObjects();
-        initMocks(this);
+        openMocks(this);
     }
 
     /**

--- a/bull-bean-transformer/src/test/java/com/hotels/beans/populator/ArrayPopulatorTest.java
+++ b/bull-bean-transformer/src/test/java/com/hotels/beans/populator/ArrayPopulatorTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -62,7 +62,7 @@ public class ArrayPopulatorTest {
      */
     @BeforeClass
     public void beforeClass() {
-        initMocks(this);
+        openMocks(this);
     }
 
     /**

--- a/bull-bean-transformer/src/test/java/com/hotels/beans/populator/PopulatorFactoryTest.java
+++ b/bull-bean-transformer/src/test/java/com/hotels/beans/populator/PopulatorFactoryTest.java
@@ -19,7 +19,7 @@ package com.hotels.beans.populator;
 import static java.util.Objects.nonNull;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.List;
 import java.util.Map;
@@ -55,7 +55,7 @@ public class PopulatorFactoryTest {
      */
     @BeforeClass
     public void beforeClass() {
-        initMocks(this);
+        openMocks(this);
     }
 
     /**

--- a/bull-bean-transformer/src/test/java/com/hotels/beans/transformer/AbstractBeanTransformerTest.java
+++ b/bull-bean-transformer/src/test/java/com/hotels/beans/transformer/AbstractBeanTransformerTest.java
@@ -16,7 +16,7 @@
 
 package com.hotels.beans.transformer;
 
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import org.mockito.InjectMocks;
 import org.testng.annotations.BeforeClass;
@@ -53,6 +53,6 @@ public abstract class AbstractBeanTransformerTest extends AbstractTransformerTes
      */
     @BeforeMethod
     void beforeMethod() {
-        initMocks(this);
+        openMocks(this);
     }
 }

--- a/bull-common/src/test/java/com/hotels/transformer/cache/CacheManagerFactoryTest.java
+++ b/bull-common/src/test/java/com/hotels/transformer/cache/CacheManagerFactoryTest.java
@@ -17,7 +17,7 @@
 package com.hotels.transformer.cache;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import org.mockito.InjectMocks;
 import org.testng.annotations.BeforeClass;
@@ -43,7 +43,7 @@ public class CacheManagerFactoryTest {
      */
     @BeforeClass
     public void beforeClass() {
-        initMocks(this);
+        openMocks(this);
     }
 
     /**

--- a/bull-common/src/test/java/com/hotels/transformer/utils/ClassUtilsTest.java
+++ b/bull-common/src/test/java/com/hotels/transformer/utils/ClassUtilsTest.java
@@ -22,7 +22,7 @@ import static java.util.Objects.nonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import static com.hotels.transformer.utils.ClassUtils.BUILD_METHOD_NAME;
 
@@ -122,7 +122,7 @@ public class ClassUtilsTest {
      */
     @BeforeClass
     public void beforeClass() {
-        initMocks(this);
+        openMocks(this);
     }
 
     /**

--- a/bull-common/src/test/java/com/hotels/transformer/utils/ReflectionUtilsTest.java
+++ b/bull-common/src/test/java/com/hotels/transformer/utils/ReflectionUtilsTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import static com.hotels.transformer.constant.MethodPrefix.GET;
 import static com.hotels.transformer.constant.MethodPrefix.IS;
@@ -109,7 +109,7 @@ public class ReflectionUtilsTest {
      */
     @BeforeClass
     public void beforeClass() {
-        initMocks(this);
+        openMocks(this);
     }
 
     /**

--- a/bull-common/src/test/java/com/hotels/transformer/validator/ValidatorTest.java
+++ b/bull-common/src/test/java/com/hotels/transformer/validator/ValidatorTest.java
@@ -20,7 +20,7 @@ import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.ZERO;
 import static java.util.Objects.nonNull;
 
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 import static org.testng.Assert.assertEquals;
 
 import java.math.BigInteger;
@@ -70,7 +70,7 @@ public class ValidatorTest {
      */
     @BeforeClass
     public void beforeClass() {
-        initMocks(this);
+        openMocks(this);
     }
 
     /**

--- a/bull-converter/src/test/java/com/hotels/beans/conversion/ConverterTest.java
+++ b/bull-converter/src/test/java/com/hotels/beans/conversion/ConverterTest.java
@@ -21,7 +21,7 @@ import static java.math.BigInteger.ZERO;
 import static java.nio.ByteBuffer.wrap;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -70,7 +70,7 @@ public class ConverterTest extends AbstractConversionTest {
      */
     @BeforeClass
     public void beforeClass() {
-        initMocks(this);
+        openMocks(this);
     }
 
     /**

--- a/bull-converter/src/test/java/com/hotels/beans/conversion/analyzer/ConversionAnalyzerTest.java
+++ b/bull-converter/src/test/java/com/hotels/beans/conversion/analyzer/ConversionAnalyzerTest.java
@@ -17,7 +17,7 @@
 package com.hotels.beans.conversion.analyzer;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -57,7 +57,7 @@ public class ConversionAnalyzerTest {
      */
     @BeforeClass
     public void beforeClass() {
-        initMocks(this);
+        openMocks(this);
     }
 
     /**

--- a/bull-converter/src/test/java/com/hotels/beans/conversion/processor/ConversionProcessorFactoryTest.java
+++ b/bull-converter/src/test/java/com/hotels/beans/conversion/processor/ConversionProcessorFactoryTest.java
@@ -17,7 +17,7 @@
 package com.hotels.beans.conversion.processor;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -57,7 +57,7 @@ public class ConversionProcessorFactoryTest {
      */
     @BeforeClass
     public void beforeClass() {
-        initMocks(this);
+        openMocks(this);
     }
 
     /**

--- a/bull-converter/src/test/java/com/hotels/beans/conversion/processor/impl/BigDecimalConversionTest.java
+++ b/bull-converter/src/test/java/com/hotels/beans/conversion/processor/impl/BigDecimalConversionTest.java
@@ -21,7 +21,7 @@ import static java.math.BigDecimal.valueOf;
 import static java.nio.ByteBuffer.wrap;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -49,7 +49,7 @@ public class BigDecimalConversionTest extends AbstractConversionTest {
      */
     @BeforeClass
     public void beforeClass() {
-        initMocks(this);
+        openMocks(this);
     }
 
     @Test

--- a/bull-converter/src/test/java/com/hotels/beans/conversion/processor/impl/BigIntegerConversionTest.java
+++ b/bull-converter/src/test/java/com/hotels/beans/conversion/processor/impl/BigIntegerConversionTest.java
@@ -21,7 +21,7 @@ import static java.math.BigInteger.valueOf;
 import static java.nio.ByteBuffer.wrap;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -49,7 +49,7 @@ public class BigIntegerConversionTest extends AbstractConversionTest {
      */
     @BeforeClass
     public void beforeClass() {
-        initMocks(this);
+        openMocks(this);
     }
 
     @Test

--- a/bull-converter/src/test/java/com/hotels/beans/conversion/processor/impl/BooleanConversionTest.java
+++ b/bull-converter/src/test/java/com/hotels/beans/conversion/processor/impl/BooleanConversionTest.java
@@ -17,7 +17,7 @@
 package com.hotels.beans.conversion.processor.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -44,7 +44,7 @@ public class BooleanConversionTest extends AbstractConversionTest {
      */
     @BeforeClass
     public void beforeClass() {
-        initMocks(this);
+        openMocks(this);
     }
 
     /**

--- a/bull-converter/src/test/java/com/hotels/beans/conversion/processor/impl/ByteArrayConversionTest.java
+++ b/bull-converter/src/test/java/com/hotels/beans/conversion/processor/impl/ByteArrayConversionTest.java
@@ -17,7 +17,7 @@
 package com.hotels.beans.conversion.processor.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -47,7 +47,7 @@ public class ByteArrayConversionTest extends AbstractConversionTest {
      */
     @BeforeClass
     public void beforeClass() {
-        initMocks(this);
+        openMocks(this);
     }
 
     @Test

--- a/bull-converter/src/test/java/com/hotels/beans/conversion/processor/impl/ByteConversionTest.java
+++ b/bull-converter/src/test/java/com/hotels/beans/conversion/processor/impl/ByteConversionTest.java
@@ -17,7 +17,7 @@
 package com.hotels.beans.conversion.processor.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -47,7 +47,7 @@ public class ByteConversionTest extends AbstractConversionTest {
      */
     @BeforeClass
     public void beforeClass() {
-        initMocks(this);
+        openMocks(this);
     }
 
     @Test

--- a/bull-converter/src/test/java/com/hotels/beans/conversion/processor/impl/CharacterConversionTest.java
+++ b/bull-converter/src/test/java/com/hotels/beans/conversion/processor/impl/CharacterConversionTest.java
@@ -19,7 +19,7 @@ package com.hotels.beans.conversion.processor.impl;
 import static java.nio.ByteBuffer.wrap;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -50,7 +50,7 @@ public class CharacterConversionTest extends AbstractConversionTest {
      */
     @BeforeClass
     public void beforeClass() {
-        initMocks(this);
+        openMocks(this);
     }
 
     @Test

--- a/bull-converter/src/test/java/com/hotels/beans/conversion/processor/impl/DoubleConversionTest.java
+++ b/bull-converter/src/test/java/com/hotels/beans/conversion/processor/impl/DoubleConversionTest.java
@@ -20,7 +20,7 @@ import static java.lang.Double.valueOf;
 import static java.nio.ByteBuffer.wrap;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -51,7 +51,7 @@ public class DoubleConversionTest extends AbstractConversionTest {
      */
     @BeforeClass
     public void beforeClass() {
-        initMocks(this);
+        openMocks(this);
     }
 
     @Test

--- a/bull-converter/src/test/java/com/hotels/beans/conversion/processor/impl/FloatConversionTest.java
+++ b/bull-converter/src/test/java/com/hotels/beans/conversion/processor/impl/FloatConversionTest.java
@@ -20,7 +20,7 @@ import static java.lang.Float.valueOf;
 import static java.nio.ByteBuffer.wrap;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -51,7 +51,7 @@ public class FloatConversionTest extends AbstractConversionTest {
      */
     @BeforeClass
     public void beforeClass() {
-        initMocks(this);
+        openMocks(this);
     }
 
     @Test

--- a/bull-converter/src/test/java/com/hotels/beans/conversion/processor/impl/IntegerConversionTest.java
+++ b/bull-converter/src/test/java/com/hotels/beans/conversion/processor/impl/IntegerConversionTest.java
@@ -19,7 +19,7 @@ package com.hotels.beans.conversion.processor.impl;
 import static java.nio.ByteBuffer.wrap;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -50,7 +50,7 @@ public class IntegerConversionTest extends AbstractConversionTest {
      */
     @BeforeClass
     public void beforeClass() {
-        initMocks(this);
+        openMocks(this);
     }
 
     @Test

--- a/bull-converter/src/test/java/com/hotels/beans/conversion/processor/impl/LongConversionTest.java
+++ b/bull-converter/src/test/java/com/hotels/beans/conversion/processor/impl/LongConversionTest.java
@@ -19,7 +19,7 @@ package com.hotels.beans.conversion.processor.impl;
 import static java.nio.ByteBuffer.wrap;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -50,7 +50,7 @@ public class LongConversionTest extends AbstractConversionTest {
      */
     @BeforeClass
     public void beforeClass() {
-        initMocks(this);
+        openMocks(this);
     }
 
     @Test

--- a/bull-converter/src/test/java/com/hotels/beans/conversion/processor/impl/ShortConversionTest.java
+++ b/bull-converter/src/test/java/com/hotels/beans/conversion/processor/impl/ShortConversionTest.java
@@ -21,7 +21,7 @@ import static java.lang.Short.valueOf;
 import static java.nio.ByteBuffer.wrap;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -52,7 +52,7 @@ public class ShortConversionTest extends AbstractConversionTest {
      */
     @BeforeClass
     public void beforeClass() {
-        initMocks(this);
+        openMocks(this);
     }
 
     @Test

--- a/bull-converter/src/test/java/com/hotels/beans/conversion/processor/impl/StringConversionTest.java
+++ b/bull-converter/src/test/java/com/hotels/beans/conversion/processor/impl/StringConversionTest.java
@@ -19,7 +19,7 @@ package com.hotels.beans.conversion.processor.impl;
 import static java.lang.String.valueOf;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -45,7 +45,7 @@ public class StringConversionTest extends AbstractConversionTest {
      */
     @BeforeClass
     public void beforeClass() {
-        initMocks(this);
+        openMocks(this);
     }
 
     @Test

--- a/bull-map-transformer/src/test/java/com/hotels/map/MapUtilsTest.java
+++ b/bull-map-transformer/src/test/java/com/hotels/map/MapUtilsTest.java
@@ -17,7 +17,7 @@
 package com.hotels.map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import org.mockito.InjectMocks;
 import org.testng.annotations.BeforeClass;
@@ -40,7 +40,7 @@ public class MapUtilsTest {
      */
     @BeforeClass
     public void beforeClass() {
-        initMocks(this);
+        openMocks(this);
     }
 
     /**

--- a/bull-map-transformer/src/test/java/com/hotels/map/transformer/MapTransformerTest.java
+++ b/bull-map-transformer/src/test/java/com/hotels/map/transformer/MapTransformerTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.util.Lists.list;
 import static org.assertj.core.util.Maps.newHashMap;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.math.BigInteger;
 import java.util.HashMap;
@@ -66,7 +66,7 @@ public class MapTransformerTest extends AbstractTransformerTest {
      */
     @BeforeClass
     public void beforeClass() {
-        initMocks(this);
+        openMocks(this);
         initObjects();
     }
 

--- a/docs/site/markdown/transformer/bean/testing.md
+++ b/docs/site/markdown/transformer/bean/testing.md
@@ -71,7 +71,7 @@ public class SampleClass {
 The test class will be:
 ```java
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
 
@@ -102,7 +102,7 @@ public class SampleClassTest {
      */
     @Before
     public void beforeMethod() {
-        initMocks(this);
+        openMocks(this);
     }
 
     /**
@@ -187,7 +187,7 @@ public class SampleClass {
 The test class will be:
 ```java
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
 import static org.mockito.ArgumentMatchers.any;
@@ -219,7 +219,7 @@ public class SampleClassTest {
      */
     @Before
     public void beforeMethod() {
-        initMocks(this);
+        openMocks(this);
     }
 
     /**
@@ -307,7 +307,7 @@ public class SampleClass {
 The test class will be:
 ```java
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.lang.reflect.Field;
 
@@ -333,7 +333,7 @@ public class SampleClassTest {
      */
     @Before
     public void beforeMethod() {
-        initMocks(this);
+        openMocks(this);
         // injects a real BeanUtils instance into the test class
         setFieldValue(underTest, "beanUtils", new BeanUtils());
     }


### PR DESCRIPTION
## Description

Replaces the Mockito deprecated method `initMocks` with the new one: `openMocks`